### PR TITLE
fixed case problem in  env_Cf_pyapps_user declaration

### DIFF
--- a/vars/all_var.yml
+++ b/vars/all_var.yml
@@ -170,7 +170,7 @@
   cf_app_pyapp_home: "{{ env_cf_app_pyapp_home }}"
   cf_app_pyapp_settings: "{{ env_cf_app_pyapp_settings }}"
   cf_app_repo_branch: "{{ env_cf_app_repo_branch }}"
-  cf_app_pyapps_user: "{{ env_cf_pyapps_user }}"
+  cf_app_pyapps_user: "{{ env_cf_app_pyapps_user }}"
   cf_app_db_user: "{{ env_cf_app_db_user }}"
   cf_app_db_pwd: "{{ env_cf_app_db_pwd }}"
   cf_app_pyapps_email: "{{ env_cf_app_pyapps_email }}"


### PR DESCRIPTION
cf_app_sg_app_zone_id had duplicate declaration. Removed second declaration.

 env_Cf_pyapps_user changed to  env_cf_app_pyapps_user