### PR TITLE
Attach External Drive to Database Server

### DIFF
--- a/roles/postgres/tasks/attach_ext_drive.yml
+++ b/roles/postgres/tasks/attach_ext_drive.yml
@@ -3,6 +3,11 @@
 # Created: 5/8/17
 # Author: '@ekivemark'
 
+- name: "Create a script directory for root account"
+  file:
+    dest: /root/script
+    state: directory
+
 - name: "Create External Drive script"
   template:
     src: "../templates/setup_ext_drive.j2"


### PR DESCRIPTION
Moved Attach_ext_drive.yml to task in roles/postgres/tasks
Added as include to tasks in playbook/dataserver/create_server_base.yml

Role_path not working so switching to relative location for template:
../templates/setup_ext_drive.j2

fix error in db_backup.sh.j2
pushing create_server_base.yml

Creating /root/script directory in attach_ext_drive.yml