### PR TITLE
Add remote_user to build_database.yml

### DIFF
--- a/playbook/dataserver/build_database.yml
+++ b/playbook/dataserver/build_database.yml
@@ -24,6 +24,7 @@
 - name: Provision Database
   hosts: dbservers
   # connection: local
+  remote_user: ec2-user
   gather_facts: True
   vars:
     env: "dev"


### PR DESCRIPTION
/hhs_ansible/hhs_ansible/ansible.cfg has remote_user = ec2-user but it doesn/t appear to be detected.