### PR TITLE
Enable build of Fips140_database.yml to use variable or default

### DIFF
--- a/playbook/dataserver/build_fips140_base.yml
+++ b/playbook/dataserver/build_fips140_base.yml
@@ -4,7 +4,7 @@
 # Author: @ekivemark
 
 - name: Provision FIPS 140.2 Server
-  hosts: dbservers
+  hosts: "{{ build_target | default('ddbservers') }}"
   # connection: smart
   gather_facts: False
   user: ec2-user


### PR DESCRIPTION
 {{ build_target | default('dbservers') }}