### PR TITLE
add_back_end_resources is defined check in django_prep.yml

### DIFF
--- a/playbook/appserver/roles/django_prep/tasks/main.yml
+++ b/playbook/appserver/roles/django_prep/tasks/main.yml
@@ -40,7 +40,7 @@
     command: "loaddata apps/fhir/server/fixtures/{{ env|lower }}_install_fixture.json"
     app_path: "{{ install_root }}/{{ project_name }}/"
     virtualenv: "{{ venv }}"
-  when: ( add_back_end_resources == 'yes' )
+  when: ( add_back_end_resources is defined ) and ( add_back_end_resources == 'yes' )
 
 - name: Django collectstatic
   become_user: root


### PR DESCRIPTION
tell swagger-ui/dist/index.html to load swagger docs via swagger_external_path