### PR TITLE
installing latest awscli

### DIFF
--- a/playbook/dataserver/roles/postgres/templates/db_backup.sh.j2
+++ b/playbook/dataserver/roles/postgres/templates/db_backup.sh.j2
@@ -31,7 +31,7 @@ PG_DATA_DIR={{ db_server_data_dir }}
 # Patch to force folders to be created for $1 in S3
 FREQ_MODE="$1"
 echo "$PG_ENVIRONMENT $FREQ_MODE" >$PG_TEMP_DIR/folder_$FREQ_MODE.txt
-/usr/local/bin/aws s3 cp $PG_TEMP_DIR/folder_$FREQ_MODE.txt s3://bb-dbback-$PG_ENVIRONMENT/$FREQ_MODE/
+/usr/bin/aws s3 cp $PG_TEMP_DIR/folder_$FREQ_MODE.txt s3://bb-dbback-$PG_ENVIRONMENT/$FREQ_MODE/
 
 # export PGPASSWORD="R3s3t_Th1s"
 export PGPASSFILE=$PG_DATA_DIR/.pgpass
@@ -41,7 +41,7 @@ echo "Postgres backup: $NOW $PG_ENVIRONMENT:$DB_TABLE_NAME on $HOST_IP:$PG_ACCES
 
 cd $PG_TEMP_DIR
 /usr/pgsql-9.6/bin/pg_dump -U $DB_USER -h $HOST_IP -p {{ db_host_port }} $DB_TABLE_NAME | /usr/bin/bzip2 | /usr/bin/openssl smime -encrypt -aes256 -binary -outform DEM -out $PG_TEMP_DIR/$HOST_IP.$DB_TABLE_NAME.$1_$NOW.sql.bz2.ssl {{ db_server_data_dir }}/{{ db_server_backup_pub_key }}
-/usr/local/bin/aws s3 mv $PG_TEMP_DIR/$HOST_IP.$DB_TABLE_NAME.$1_$NOW.sql.bz2.ssl s3://bb-dbback-$PG_ENVIRONMENT/$1/
+/usr/bin/aws s3 mv $PG_TEMP_DIR/$HOST_IP.$DB_TABLE_NAME.$1_$NOW.sql.bz2.ssl s3://bb-dbback-$PG_ENVIRONMENT/$1/
 
 # Add cleanup process in case move failed
 ( "$PG_DATA_DIR/db_cleanup.sh" "$1" "db_backup" )

--- a/playbook/dataserver/roles/postgres/templates/db_cleanup.sh.j2
+++ b/playbook/dataserver/roles/postgres/templates/db_cleanup.sh.j2
@@ -24,19 +24,19 @@ echo "Postgres cleanup: $CLEAN_NOW in $PG_CLEAN_TEMP_DIR started:$1 $2 $CLEAN_NO
 cd $PG_CLEAN_TEMP_DIR
 
 # Get the list from S3 for mode $1
-/usr/local/bin/aws s3 ls  s3://bb-dbback-$PG_CLEAN_ENVIRONMENT/$1/ >$PG_CLEAN_TEMP_DIR/cleanup.s3.list.tmp
+/usr/bin/aws s3 ls  s3://bb-dbback-$PG_CLEAN_ENVIRONMENT/$1/ >$PG_CLEAN_TEMP_DIR/cleanup.s3.list.tmp
 
 # Get the local list of backups
-if compgen -G "$PG_CLEAN_TEMP_DIR/$CLEAN_DB_TABLE_NAME.*" >/dev/null ; then
+if compgen -G "$PG_CLEAN_TEMP_DIR/$HOST_IP.$CLEAN_DB_TABLE_NAME.*" >/dev/null ; then
    ls -la *.ssl >$PG_CLEAN_TEMP_DIR/cleanup.local.list.tmp
 
    for mvfile in $PG_CLEAN_TEMP_DIR/$CLEAN_DB_TABLE_NAME.$1_*
    do
      # Move the file to S3
      # echo "moving $mvfile to S3"
-     /usr/local/bin/aws s3 mv $mvfile  s3://bb-dbback-$PG_CLEAN_ENVIRONMENT/$1/
+     /usr/bin/aws s3 mv $mvfile  s3://bb-dbback-$PG_CLEAN_ENVIRONMENT/$1/
      # echo "S3 Bucket content:"
-     # /usr/local/bin/aws s3 ls s3://bb-dbback-$PG_CLEAN_ENVIRONMENT/$1/
+     # /usr/bin/aws s3 ls s3://bb-dbback-$PG_CLEAN_ENVIRONMENT/$1/
      if [ -f "$mvfile" ]; then
         echo "File $mvfile  move to S3 failed" >>$PG_CLEAN_TEMP_DIR/cleanup.log"
         echo "$mvfile move failed"

--- a/playbook/dataserver/roles/update_awscli/tasks/main.yml
+++ b/playbook/dataserver/roles/update_awscli/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+# File: playbook/datasever/roles/update_awscli/tasks/main.yml
+# Created: 8/28/17
+# Author: '@ekivemark'
+
+# update pip and awscli
+# needs latest version of awscli for copy with fips enabled.
+
+
+- name: "Install pip via yum"
+  become_user: root
+  become: yes
+  yum:
+    name: "python-pip"
+    state: present
+
+- name: "upgrade pip and awscli with -i option"
+  become_user: root
+  become: yes
+  pip:
+    name: "{{ item }}"
+    umask: 0022
+    extra_args: "-- upgrade -i https://pypi.org/simple/ "
+  with_items:
+    - pip
+    - awscli
+
+

--- a/playbook/dataserver/set_backup_tasks.yml
+++ b/playbook/dataserver/set_backup_tasks.yml
@@ -5,6 +5,8 @@
 
 - include: ../../roles/base_patch/tasks/set_db_aws_credentials.yml
 
+- include: ./roles/update_awscli/tasks/main.yml
+
 - include: ./roles/postgres/tasks/pgpass.yml
 
 - include: ./roles/postgres/tasks/backup.yml


### PR DESCRIPTION
Coping with FIPS enabled. pip doesn't work as normal with FIPS Enabled because MD5 hash is not permitted.