### PR TITLE
yum upgrade needs skip-broken

### DIFF
--- a/roles/base_patch/tasks/main.yml
+++ b/roles/base_patch/tasks/main.yml
@@ -23,7 +23,7 @@
 #  yum:
 #    name: "*"
 #    state: latest
-  shell: yum upgrade --skip-broken
+  shell: yum upgrade -y  --skip-broken
 
 - name: "check sshd config"
   become_user: root


### PR DESCRIPTION
--skip broken is only added to ansible in v2.3 (we are on 2.2.2.1)
switch to using shell command
add -y to avoid user prompt
