### PR TITLE
adding install parameter to overcome error

### DIFF
--- a/playbook/appserver/roles/app_update/tasks/main.yml
+++ b/playbook/appserver/roles/app_update/tasks/main.yml
@@ -157,7 +157,7 @@
     {{ cf_app_py_virtual_env }}/bin/pip{{ python_ver }} {{ item }}
   with_items:
     - "install --upgrade pip {{ pip_extra_args }} "
-    - "install psycopg2 {{ pip_extra_args }} "
+    - "install psycopg2 {{ pip_extra_args }} --allow-external psycopg2 "
     - "install -r {{ cf_app_pyapp_home }}/{{ common_project_name }}/requirements/requirements.txt {{ pip_extra_args }} "
 
 # Relative reference from playbook/appserver


### PR DESCRIPTION
in psycopg2 install - needs --allow-external psycopg2