### PR TITLE
fixing reboot fail in base_patch

### DIFF
--- a/roles/base_patch/tasks/main.yml
+++ b/roles/base_patch/tasks/main.yml
@@ -43,7 +43,7 @@
 - name: "Rebooting .... If {{ reboot_hint.stdout }} Required"
   become_user: "{{ remote_admin_account }}"
   become: yes
-  command: shutdown -r now "Reboot required for updated kernel"
+  shell: "shutdown -r -t 5  'Reboot required for updated kernel' "
   async: 0
   poll: 0
   ignore_errors: true
@@ -59,7 +59,7 @@
 #  register: rebooting
 
 
-- name: "Waiting 120 seconds for instance to reboot..."
-  pause: seconds=120
+- name: "Waiting 180 seconds for instance to reboot..."
+  pause: seconds=180
   when: rebooting|changed
 


### PR DESCRIPTION
wait 5 seconds before rebooting to allow ansible to log off
Then wait 180 seconds for reboot.