### PR TITLE
Export app info

### DIFF
--- a/playbook/appherd/910_add_cron_exports.yml
+++ b/playbook/appherd/910_add_cron_exports.yml
@@ -1,0 +1,82 @@
+---
+# File: playbook/appherd/910_add_cron_exports.yml.yml
+# Created: 2/14/18
+# Author: '@ekivemark'
+#
+# Playbook to:
+#  - Add a script to the appserver
+#  - Setup a weekly Cron job to export application information to splunk
+#    via the /var/log/pyapps/info.log
+#
+#  - Only needs to run on one server
+#  - Run weekly Sundays at 7pm ET
+
+#
+# Based on: http://odecee.com.au/cloudformation-and-ansible/
+# Vars file is relative to playbook file
+# vars_files:
+# Vars file is relative to playbook file
+# Sequence:
+# 1. Common variables
+# 2. encrypted vault file
+# 3. environment specific variables
+# 4. all_vars which reference the preceding three files.
+# common_ prefixes common variables
+# vault_env_ prefixes encrypted variables
+# env_ prefixes environment specific variables
+# all_var incorporates preceding variables and defines variables without prefixes.
+# use all_var variables in scripts.
+
+# new base machines will be in appservers-base in /etc/ansible/hosts
+# add all the base software and move the server to appservers and
+# remove from appservers-base
+
+- name: "what version of python/django is running?"
+  # hosts: appservers
+  hosts: "{{ build_target | default('appservers') }}"
+  # connection: local
+  remote_user: ec2-user
+  # become_user: "{{ remote_admin_account }}"
+  # become: yes
+  gather_facts: True
+  vars:
+    ansible_ssh_pipelining: no
+    # The variables in this section can all be overridden in the vars_files
+    # that follow
+    env: "test"
+    azone: "az1"
+    sub_zone: "app"
+    sg_zone: "appserver"
+    env_az: "{{ env }}-{{ azone }}"
+    env_cf_app_version: "01"
+    # splunk_target_layer: "WEB | APP | DATA | MGMT"
+    splunk_target_layer: "{{ sub_zone|upper }}"
+    migrate: "yes"
+    collectstatic: "yes"
+    # Setting the playbook value for SNS Notifications
+    sns_playbook: "playbook/appserver/build_appserver.yml"
+    sns_subject: "export app info to splunk"
+    sns_playbook_action: "export_info"
+    sns_debug: false
+
+  vars_files:
+    - "./../../vars/common.yml"
+    - "./../../vault/env/{{ env }}/vault.yml"
+    - "./../../vars/env/{{ env }}/env.yml"
+    - "./../../vars/all_var.yml"
+
+  # ../../roles/ points to roles stored in roles at the top level
+  # - roles/ indicates the role is in this playbook directory
+
+  tasks:
+  - name: "Use management command to export data to info.log"
+    become_user: "{{ remote_admin_account }}"
+    become: yes
+    run_once: yes
+    shell: |
+      source {{ cf_app_py_virtual_env }}/bin/activate
+      cd {{ install_root }}/{{ project_name }}/
+      echo "$(date --iso-8601=seconds) Active_BBAPI_Applications:$({{ cf_app_py_virtual_env }}/bin/python3 manage.py dumpdata dot_ext.application --indent 2 |grep \"active\": | wc -l ) " >>{{ cf_app_log_dir }}/info.log
+
+
+

--- a/vars/env/test/env.yml
+++ b/vars/env/test/env.yml
@@ -125,7 +125,7 @@ env_django_email_backend: "django_ses.SESBackend"
 
 env_django_email_region: "us-east-1"
 env_django_email_ses_endpoint: "email.us-east-1.amazonaws.com"
-env_django_from_email: "bluebutton.test@fhirservice.net"
+env_django_from_email: "BlueButtonAPI@cms.hhs.gov"
 env_django_admin_email: "mark.scrimshire@cms.hhs.gov"
 
 # Require Invite to Register


### PR DESCRIPTION
This script can be run from Jenkins once each week (mainly on IMPL and PROD) 
it would export the active_apps count to a log that is captured by splunk.