### PR TITLE
CBBF-150 Use amazon's ntp server to keep server clocks in sync

### DIFF
--- a/roles/base_patch/tasks/main.yml
+++ b/roles/base_patch/tasks/main.yml
@@ -17,3 +17,16 @@
   become_user: "{{ remote_admin_account }}"
   become: yes
   shell: yum update-minimal --security -y
+
+- name: "add amazon ntp server to chrony.conf"
+  lineinfile:
+    path: /etc/chrony.conf
+    insertafter: EOF
+    line: 'server 169.254.169.123 prefer iburst'
+  become: yes
+
+- name: "restart chronyd"
+  service:
+    name: chronyd
+    state: restarted
+  become: yes


### PR DESCRIPTION
I've already applied these changes to the running app servers, so the issue with clock drift should be resolved. I'm adding the changes here so that, going forward, freshly created servers will also keep their clocks in sync.

Based on: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-time.html