### PR TITLE
CBBP-891 Process to build and deploy AMIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 tmp/
+terraform.tfstate
+terraform.tfstate.backup
+.terraform
+*.tfvars
 *.retry

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 tmp/
+*.retry

--- a/Jenkinsfiles/Jenkinsfile.build_ami
+++ b/Jenkinsfiles/Jenkinsfile.build_ami
@@ -55,6 +55,27 @@ pipeline {
       }
     }
 
+    stage('Notify HipChat') {
+      steps {
+        withCredentials([
+          string(credentialsId: 'hipchat-room', variable: 'room'),
+          string(credentialsId: 'hipchat-server', variable: 'server'),
+          string(credentialsId: 'hipchat-token', variable: 'token')
+        ]) {
+          hipchatSend(
+            color: 'GRAY',
+            notify: true,
+            message: "STARTED: ${env.JOB_NAME} [${params.ENV}]",
+            room: room,
+            sendAs: '',
+            server: server,
+            token: token,
+            v2enabled: true
+          )
+        }
+      }
+    }
+
     stage('Install requirements') {
       steps {
         dir('code') {
@@ -131,6 +152,46 @@ pipeline {
             }
           }
         }
+      }
+    }
+  }
+
+  post {
+    success {
+      withCredentials([
+        string(credentialsId: 'hipchat-room', variable: 'room'),
+        string(credentialsId: 'hipchat-server', variable: 'server'),
+        string(credentialsId: 'hipchat-token', variable: 'token')
+      ]) {
+        hipchatSend(
+            color: 'GREEN',
+            notify: true,
+            message: "SUCCESS: ${env.JOB_NAME} [${params.ENV}]",
+            room: room,
+            sendAs: '',
+            server: server,
+            token: token,
+            v2enabled: true
+        )
+      }
+    }
+
+    failure {
+      withCredentials([
+        string(credentialsId: 'hipchat-room', variable: 'room'),
+        string(credentialsId: 'hipchat-server', variable: 'server'),
+        string(credentialsId: 'hipchat-token', variable: 'token')
+      ]) {
+        hipchatSend(
+          color: 'RED',
+          notify: true,
+          message: "FAILED: ${env.JOB_NAME} [${params.ENV}]",
+          room: room,
+          sendAs: '',
+          server: server,
+          token: token,
+          v2enabled: true
+        )
       }
     }
   }

--- a/Jenkinsfiles/Jenkinsfile.build_ami
+++ b/Jenkinsfiles/Jenkinsfile.build_ami
@@ -1,0 +1,137 @@
+def private_key = 'dev-key'
+def vault_pass = 'vault-pass'
+def aws_creds = 'cbj-deploy'
+
+pipeline {
+  agent {
+    node {
+      label ''
+      customWorkspace 'blue-button-build-ami'
+    }
+  }
+
+  parameters {
+    string(
+      defaultValue: "",
+      description: 'The branch of the application repo to build. Required.',
+      name: 'BRANCH'
+    )
+    string(
+      defaultValue: "*/master",
+      description: 'The branch of the deployment repo to use for the build.',
+      name: 'BUILD_BRANCH'
+    )
+    string(
+      defaultValue: "",
+      description: 'The Gold Image AMI id that will be used as the base for app servers.',
+      name: 'AMI_ID'
+    )
+    string(
+      defaultValue: "",
+      description: 'The subnet ID where the build server will be launched.',
+      name: 'SUBNET_ID'
+    )
+    string(
+      defaultValue: "m3.medium",
+      description: 'The class/size of the ec2 instance to launch.',
+      name: 'INSTANCE_CLASS'
+    )
+    choice(
+      choices: 'dev\ntest\nimpl\nprod',
+      description: 'The environment to deploy to. Required.',
+      name: 'ENV'
+    )
+  }
+
+  stages {
+    stage('Ensure BRANCH, ENV, AMI_ID and SUBNET_ID') {
+      steps {
+        sh """
+        if [ -z "${params.BRANCH}" ] || [ -z "${params.ENV}" ] || [ -z "${params.AMI_ID}" ] || [ -z "${params.SUBNET_ID}" ]
+        then
+          exit 1
+        fi
+        """
+      }
+    }
+
+    stage('Install requirements') {
+      steps {
+        dir('code') {
+          script {
+            sh """
+              virtualenv -ppython2.7 venv
+              . venv/bin/activate
+
+              pip install --upgrade pip
+              pip install --upgrade cffi
+
+              pip install ansible==2.4.2.0
+              pip install boto
+            """
+          }
+        }
+      }
+    }
+
+    stage('Set private key file') {
+      steps {
+        script {
+            private_key = 'prod-key'
+        }
+      }
+      when {
+        expression {
+          params.ENV == "prod"
+        }
+      }
+    }
+
+    stage('Checkout') {
+      steps {
+        checkout([
+          $class: 'GitSCM',
+          branches: [[
+            name: "${params.BUILD_BRANCH}"
+          ]],
+          doGenerateSubmoduleConfigurations: false,
+          extensions: [[
+            $class: 'RelativeTargetDirectory',
+            relativeTargetDir: 'code'
+          ]],
+          userRemoteConfigs: [[
+            url: 'https://github.com/CMSgov/bluebutton-web-deployment.git'
+          ]]
+        ])
+      }
+    }
+
+    stage('Build AMI') {
+      steps {
+        script {
+          dir('code') {
+            withAwsCli(credentialsId: aws_creds, defaultRegion: 'us-east-1') {
+              withCredentials([
+                file(credentialsId: private_key, variable: 'pk'),
+                file(credentialsId: vault_pass, variable: 'vp')
+              ]) {
+                sh """
+                  . venv/bin/activate
+
+                  ansible-playbook playbook/build_ami/main.yml  \
+                    --vault-password-file ${vp} \
+                    --private-key ${pk} \
+                    -e 'git_branch=${params.BRANCH}' \
+                    -e 'env=${params.ENV}' \
+                    -e 'cf_app_instance_type=${params.INSTANCE_CLASS}' \
+                    -e 'build_subnet_id=${params.SUBNET_ID}' \
+                    -e 'ami_app_gold_image=${params.AMI_ID}'
+                """
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/Jenkinsfiles/Jenkinsfile.deploy_ami
+++ b/Jenkinsfiles/Jenkinsfile.deploy_ami
@@ -45,6 +45,27 @@ pipeline {
       }
     }
 
+    stage('Notify HipChat') {
+      steps {
+        withCredentials([
+          string(credentialsId: 'hipchat-room', variable: 'room'),
+          string(credentialsId: 'hipchat-server', variable: 'server'),
+          string(credentialsId: 'hipchat-token', variable: 'token')
+        ]) {
+          hipchatSend(
+            color: 'GRAY',
+            notify: true,
+            message: "STARTED: ${env.JOB_NAME} [${params.ENV}]",
+            room: room,
+            sendAs: '',
+            server: server,
+            token: token,
+            v2enabled: true
+          )
+        }
+      }
+    }
+
     stage('Checkout') {
       steps {
         checkout([
@@ -86,7 +107,6 @@ pipeline {
         }
       }
     }
-
 
     stage('Sanity check terraform plan') {
       steps {
@@ -150,6 +170,46 @@ pipeline {
             }
           }
         }
+      }
+    }
+  }
+
+  post {
+    success {
+      withCredentials([
+        string(credentialsId: 'hipchat-room', variable: 'room'),
+        string(credentialsId: 'hipchat-server', variable: 'server'),
+        string(credentialsId: 'hipchat-token', variable: 'token')
+      ]) {
+        hipchatSend(
+            color: 'GREEN',
+            notify: true,
+            message: "SUCCESS: ${env.JOB_NAME} [${params.ENV}]",
+            room: room,
+            sendAs: '',
+            server: server,
+            token: token,
+            v2enabled: true
+        )
+      }
+    }
+
+    failure {
+      withCredentials([
+        string(credentialsId: 'hipchat-room', variable: 'room'),
+        string(credentialsId: 'hipchat-server', variable: 'server'),
+        string(credentialsId: 'hipchat-token', variable: 'token')
+      ]) {
+        hipchatSend(
+          color: 'RED',
+          notify: true,
+          message: "FAILED: ${env.JOB_NAME} [${params.ENV}]",
+          room: room,
+          sendAs: '',
+          server: server,
+          token: token,
+          v2enabled: true
+        )
       }
     }
   }

--- a/Jenkinsfiles/Jenkinsfile.deploy_ami
+++ b/Jenkinsfiles/Jenkinsfile.deploy_ami
@@ -50,7 +50,7 @@ pipeline {
         checkout([
           $class: 'GitSCM',
           branches: [[
-            name: "${params.BUILD_BRANCH}"
+            name: "${params.DEPLOY_BRANCH}"
           ]],
           doGenerateSubmoduleConfigurations: false,
           extensions: [[

--- a/Jenkinsfiles/Jenkinsfile.deploy_ami
+++ b/Jenkinsfiles/Jenkinsfile.deploy_ami
@@ -1,0 +1,156 @@
+def aws_creds = 'cbj-deploy'
+def backend_config = ''
+def terraform_vars = ''
+
+pipeline {
+  agent {
+    node {
+      label ''
+      customWorkspace 'blue-button-deploy-ami'
+    }
+  }
+
+  parameters {
+    string(
+      defaultValue: "*/master",
+      description: 'The branch of the deployment repo to use for the build.',
+      name: 'DEPLOY_BRANCH'
+    )
+    string(
+      defaultValue: "",
+      description: 'The Blue Button AMI id that will be used for the deployment.',
+      name: 'AMI_ID'
+    )
+    string(
+      defaultValue: "m3.medium",
+      description: 'The class/size of the ec2 instance to launch.',
+      name: 'INSTANCE_CLASS'
+    )
+    choice(
+      choices: 'dev\ntest\nimpl\nprod',
+      description: 'The environment to deploy to. Required.',
+      name: 'ENV'
+    )
+  }
+
+  stages {
+    stage('Ensure ENV and AMI_ID') {
+      steps {
+        sh """
+        if [ -z "${params.BRANCH}" ] || [ -z "${params.ENV}" ] || [ -z "${params.AMI_ID}" ] || [ -z "${params.SUBNET_ID}" ]
+        then
+          exit 1
+        fi
+        """
+      }
+    }
+
+    stage('Checkout') {
+      steps {
+        checkout([
+          $class: 'GitSCM',
+          branches: [[
+            name: "${params.BUILD_BRANCH}"
+          ]],
+          doGenerateSubmoduleConfigurations: false,
+          extensions: [[
+            $class: 'RelativeTargetDirectory',
+            relativeTargetDir: 'code'
+          ]],
+          userRemoteConfigs: [[
+            url: 'https://github.com/CMSgov/bluebutton-web-deployment.git'
+          ]]
+        ])
+      }
+    }
+
+    stage('Determine terraform config files') {
+      steps {
+        script {
+          if (params.ENV == 'dev') {
+            backend_config = 'bb-backend-dev'
+            terraform_vars = 'bb-tf-dev'
+          }
+          if (params.ENV == 'test') {
+            backend_config = 'bb-backend-test'
+            terraform_vars = 'bb-tf-test'
+          }
+          if (params.ENV == 'impl') {
+            backend_config = 'bb-backend-impl'
+            terraform_vars = 'bb-tf-impl'
+          }
+          if (params.ENV == 'prod') {
+            backend_config = 'bb-backend-prod'
+            terraform_vars = 'bb-tf-prod'
+          }
+        }
+      }
+    }
+
+
+    stage('Sanity check terraform plan') {
+      steps {
+        script {
+          dir('code') {
+            withAwsCli(credentialsId: aws_creds, defaultRegion: 'us-east-1') {
+              withCredentials([
+                file(credentialsId: backend_config, variable: 'bc'),
+                file(credentialsId: terraform_vars, variable: 'tv')
+              ]) {
+                sh """
+                  cd terraform/${params.ENV}
+
+                  export TF_CLI_ARGS="-no-color"
+
+                  terraform init -backend-config=$bc
+
+                  TF_OUT=\$(terraform plan \
+                    -var-file=$tv \
+                    -var 'ami_id=${params.AMI_ID}')
+
+                  TF_ASG_CHECK=\$(echo "\$TF_OUT" | grep "aws_autoscaling_group.main")
+                  TF_LC_CHECK=\$(echo "\$TF_OUT" | grep "aws_launch_configuration.app")
+                  TF_AMI_CHECK=\$(echo "\$TF_OUT" | grep "image_id:.*(forces new resource)")
+                  TF_PLAN_CHECK=\$(echo "\$TF_OUT" | grep "Plan: 2 to add, 0 to change, 2 to destroy.")
+
+                  if [ -z "\$TF_ASG_CHECK" ] || [ -z "\$TF_LC_CHECK" ] || [ -z "\$TF_AMI_CHECK" ] || [ -z "\$TF_PLAN_CHECK" ]
+                  then
+                    echo "Terraform plan does not match expectations."
+                    exit 1
+                  fi
+                """
+              }
+            }
+          }
+        }
+      }
+    }
+
+    stage('Deploy AMI') {
+      steps {
+        script {
+          dir('code') {
+            withAwsCli(credentialsId: aws_creds, defaultRegion: 'us-east-1') {
+              withCredentials([
+                file(credentialsId: backend_config, variable: 'bc'),
+                file(credentialsId: terraform_vars, variable: 'tv')
+              ]) {
+                sh """
+                  cd terraform/${params.ENV}
+
+                  export TF_CLI_ARGS="-no-color"
+
+                  terraform init -backend-config=$bc
+                  terraform apply \
+                    -var-file=$tv \
+                    -var 'ami_id=${params.AMI_ID}' \
+                    -auto-approve
+                """
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/playbook/appherd/roles/apache/tasks/main.yml
+++ b/playbook/appherd/roles/apache/tasks/main.yml
@@ -37,7 +37,6 @@
     state: directory
     mode: "0755"
 
-
 - name: "Check Apache is running"
   become_user: "{{ remote_admin_account }}"
   become: yes

--- a/playbook/appherd/roles/app_logs/tasks/main.yml
+++ b/playbook/appherd/roles/app_logs/tasks/main.yml
@@ -42,26 +42,3 @@
     setype: httpd_sys_content_t
     state: present
   ignore_errors: True
-
-
-#- name: "Create the error log"
-#  become_user: "{{ remote_admin_account }}"
-#  become: yes
-#  file:
-#    dest: "{{ cf_app_log_dir }}/error.log"
-#    owner: "{{ cf_app_pyapps_user }}"
-#    group: logreader
-#    state: touch
-#    mode: 0766
-#
-#- name: "Create the info log"
-#  become_user: "{{ remote_admin_account }}"
-#  become: yes
-#  file:
-#    dest: "{{ cf_app_log_dir }}/info.log"
-#    owner: "{{ cf_app_pyapps_user }}"
-#    group: logreader
-#    state: touch
-#    mode: 0766
-
-

--- a/playbook/appherd/roles/copy_issued_cert/tasks/main.yml
+++ b/playbook/appherd/roles/copy_issued_cert/tasks/main.yml
@@ -35,7 +35,3 @@
     - { "name": "cert.pem", "content": "{{ apache_cert_file }}" }
     - { "name": "key.pem", "content": "{{ apache_key_file }}" }
     - { "name": "fullchain.pem", "content": "{{ apache_fullchain_file }}" }
-
-# apache_cert_file: "env_apache_cert_file" : "vault_env_apache_cert_file"
-# apache_key_file: "env_apache_key_file" : "vault_env_apache_key_file"
-# apache_fullchain_file: "env_apache_fullchain_file" : "vault_env_apache_fullchain_file"

--- a/playbook/appherd/roles/create_superuser/tasks/main.yml
+++ b/playbook/appherd/roles/create_superuser/tasks/main.yml
@@ -64,7 +64,6 @@
     DJANGO_SETTINGS_MODULE: "{{ django_settings_module }}"
   register: superuser_made_count
 
-
 - name: "superuser count"
   debug:
     msg: "Superuser count = {{ superuser_made_count.stdout }}"

--- a/playbook/build_ami/main.yml
+++ b/playbook/build_ami/main.yml
@@ -165,9 +165,9 @@
         region: '{{ cf_region }}'
         instance_id: "{{ ansible_ec2_instance_id }}"
         wait: yes
-        name: "bb-{{ env }}-{{ git_branch }}-latest"
+        name: "bb-{{ env }}-{{ git_branch }}-{{ ansible_date_time.date }}"
         tags:
-          Name: "bb-{{ env }}-{{ git_branch }}-latest"
+          Name: "bb-{{ env }}-{{ git_branch }}-{{ ansible_date_time.date }}"
           Application: "{{ cf_tags_application }}"
           Environment: "{{ env|upper }}"
           Function: "{{ cf_app_tag_key_layer }}-AppServer"

--- a/playbook/build_ami/main.yml
+++ b/playbook/build_ami/main.yml
@@ -11,8 +11,6 @@
     env_az: "{{ env }}-{{ azone }}"
     env_cf_data_version: "20"
     env_cf_app_version: "01"
-    migrate: "yes"
-    collectstatic: "yes"
     build_subnet_id: null
   vars_files:
     - "./../../vars/common.yml"

--- a/playbook/build_ami/main.yml
+++ b/playbook/build_ami/main.yml
@@ -60,7 +60,7 @@
         delay: 5
 
 - name: Provision server
-  hosts: all
+  hosts: build_servers
   remote_user: ec2-user
   gather_facts: no
   vars:

--- a/playbook/build_ami/main.yml
+++ b/playbook/build_ami/main.yml
@@ -1,0 +1,183 @@
+---
+- name: Start server for AMI build
+  hosts: localhost
+  connection: local
+  vars:
+    ansible_ssh_pipelining: no
+    env: "dev"
+    azone: "az1"
+    sub_zone: "app"
+    sg_zone: "appserver"
+    env_az: "{{ env }}-{{ azone }}"
+    env_cf_data_version: "20"
+    env_cf_app_version: "01"
+    migrate: "yes"
+    collectstatic: "yes"
+    build_subnet_id: null
+  vars_files:
+    - "./../../vars/common.yml"
+    - "./../../vault/env/{{ env }}/vault.yml"
+    - "./../../vars/env/{{ env }}/env.yml"
+    - "./../../vars/all_var.yml"
+
+  pre_tasks:
+    - name: "Create Base EC2 machine to build appserver"
+      ec2:
+        instance_type: "{{ cf_app_instance_type }}"
+        group: "BB-SG-{{ env|upper }}-{{ sg_zone|upper }}-ALLZONE" # Change the security group name here
+        image: "{{ ami_app_gold_image }}" # Change the AMI, from which you want to launch the server
+        key_name: "{{ cf_app_key_name }}" # Change the keypair name
+        region: "{{ aws_region }}"
+        tenancy: "dedicated"
+        vpc_subnet_id: "{{ build_subnet_id }}"
+        count: 1
+        termination_protection: no
+        wait: yes
+        wait_timeout: 500
+
+        # tags to instance_tags
+        instance_tags:
+          Name: "bb-{{ env }}-{{ azone }}-ami-build"
+          Stack: "BB-{{ env|upper }}-{{ cf_app_azone|upper }}-{{ cf_app_tag_key_layer|upper }}-ANSIBLE"
+          Business: "{{ cf_tags_business }}"
+          Application: "{{ cf_tags_application }}"
+          Environment: "{{ env|upper }}"
+          Function: "{{ cf_app_tag_key_layer }}-AppServer"
+          Layer:  "{{ cf_app_tag_key_layer|upper }}"
+          ami_name: "BB-{{ env|upper }}-{{ cf_app_tag_key_layer|upper }}"
+          region: "{{ cf_region }}"
+          Managed: "BB-MANAGED-{{ env|upper }}"
+          State: "ami-build"
+      register: app_ec2_output
+
+    - name: "Add new instance to inventory ( {{ app_ec2_output.instances[0]['private_ip'] }} ) "
+      add_host:
+        name: "{{ app_ec2_output.instances[0]['private_ip'] }}"
+        groups: build_servers
+
+    - name: "Wait for SSH to become available"
+      wait_for:
+        port: 22
+        host: "{{ app_ec2_output.instances[0]['private_ip'] }}"
+        delay: 5
+
+- name: Provision server
+  hosts: all
+  remote_user: ec2-user
+  gather_facts: no
+  vars:
+    ansible_ssh_pipelining: no
+    env: "dev"
+    azone: "az1"
+    sub_zone: "app"
+    sg_zone: "appserver"
+    env_az: "{{ env }}-{{ azone }}"
+    env_cf_data_version: "20"
+    env_cf_app_version: "01"
+    splunk_target_layer: "app"
+  vars_files:
+    - "./../../vars/common.yml"
+    - "./../../vault/env/{{ env }}/vault.yml"
+    - "./../../vars/env/{{ env }}/env.yml"
+    - "./../../vars/all_var.yml"
+
+  roles:
+    - ../../roles/base_patch
+    - ../../roles/snmp_update_public
+    - ../../roles/nessus_update_key
+    - ../../roles/add_authorized_keys
+    - ../../roles/splunk
+
+    - ../appherd/roles/selinux_state
+    - ../appherd/roles/aws_config
+    - ../appherd/roles/app_tools
+    - ../appherd/roles/app_user
+    - ../appherd/roles/app_logs
+    - ../appherd/roles/python34
+    - ../appherd/roles/create_apache_cert_store
+    - ../appherd/roles/install_fhircerts_to_store
+    - ../appherd/roles/copy_issued_cert
+    - ../appherd/roles/apache
+    - ../appherd/roles/swagger_ui_install
+
+    - ../appherd/roles/app_prep
+    - ../appherd/roles/app_update
+    - ../appherd/roles/log_rotate
+    - ../appherd/roles/app_update_env
+    - ../appherd/roles/create_env_settings
+    - ../appherd/roles/mod_wsgi
+
+    - ../appherd/roles/semanage_apps
+    - ../appherd/roles/semanage_virtualenv
+
+  post_tasks:
+    - name: Gather instance metadata
+      ec2_metadata_facts:
+
+    - import_tasks: ../appherd/roles/create_superuser/tasks/main.yml
+
+    - name: "Reboot the instance"
+      shell: sleep 2 && /sbin/shutdown -r now
+      async: 1
+      poll: 0
+      become: yes
+
+    - name: "Wait for the instance to initiate reboot"
+      wait_for:
+        host: "{{ ansible_ssh_host }}"
+        port: 22
+        state: stopped
+      connection: local
+
+    - name: "Wait for instance to finish reboot"
+      wait_for:
+        port: 22
+        host: '{{ ansible_ssh_host }}'
+        delay: 5
+      connection: local
+
+    - name: "Restart Apache on {{ env }}"
+      become: yes
+      service:
+        name: httpd
+        state: restarted
+        enabled: yes
+
+    - name: "call with curl to localhost"
+      shell: "curl -I -k https://localhost/"
+      register: curl_output
+      ignore_errors: yes
+
+    - name: "Result of curl was..."
+      debug:
+        msg: "{{ curl_output.stdout }}"
+
+    - name: "Stop the build server"
+      ec2:
+        instance_ids: '{{ ansible_ec2_instance_id }}'
+        region: '{{ cf_region }}'
+        state: stopped
+        wait: yes
+      delegate_to: localhost
+
+    - name: "Create an AMI"
+      ec2_ami:
+        region: '{{ cf_region }}'
+        instance_id: "{{ ansible_ec2_instance_id }}"
+        wait: yes
+        name: "bb-{{ env }}-{{ git_branch }}-latest"
+        tags:
+          Name: "bb-{{ env }}-{{ git_branch }}-latest"
+          Application: "{{ cf_tags_application }}"
+          Environment: "{{ env|upper }}"
+          Function: "{{ cf_app_tag_key_layer }}-AppServer"
+          Layer:  "{{ cf_app_tag_key_layer|upper }}"
+      delegate_to: localhost
+
+    - name: "Terminate the build server"
+      ec2:
+        instance_ids: '{{ ansible_ec2_instance_id }}'
+        region: '{{ cf_region }}'
+        state: absent
+        wait: yes
+      delegate_to: localhost

--- a/playbook/build_ami/main.yml
+++ b/playbook/build_ami/main.yml
@@ -160,14 +160,17 @@
         wait: yes
       delegate_to: localhost
 
+    - set_fact:
+        ts: "{{lookup('pipe','date +%Y%m%d%H%M%S')}}"
+
     - name: "Create an AMI"
       ec2_ami:
         region: '{{ cf_region }}'
         instance_id: "{{ ansible_ec2_instance_id }}"
         wait: yes
-        name: "bb-{{ env }}-{{ git_branch }}-{{ ansible_date_time.date }}"
+        name: "bb-{{ env }}-{{ git_branch }}-{{ ts }}"
         tags:
-          Name: "bb-{{ env }}-{{ git_branch }}-{{ ansible_date_time.date }}"
+          Name: "bb-{{ env }}-{{ git_branch }}-{{ ts }}"
           Application: "{{ cf_tags_application }}"
           Environment: "{{ env|upper }}"
           Function: "{{ cf_app_tag_key_layer }}-AppServer"

--- a/roles/snmp_update_public/tasks/main.yml
+++ b/roles/snmp_update_public/tasks/main.yml
@@ -13,17 +13,20 @@
     backrefs: yes
     regexp: 'com2sec notConfigUser  default       public'
     line: 'com2sec notConfigUser  default       {{ snmp_community_string }}'
+  become: yes
   ignore_errors: yes
 
 - name: "test for community string = public"
   shell: "cat /etc/snmp/snmpd.conf | grep com2sec"
   register: presence
+  become: yes
   ignore_errors: yes
 
 - name: "restart snmp"
   service:
     name: snmpd
     state: restarted
+  become: yes
   ignore_errors: yes
 
 - debug:

--- a/roles/splunk/templates/splunk_deployment_conf.j2
+++ b/roles/splunk/templates/splunk_deployment_conf.j2
@@ -1,5 +1,5 @@
 [deployment-client]
-clientName = {{ env_splunk_group_name }}-{{ env|upper }}-{{ cf_app_tag_key_layer|upper }}-{{ app_ip_last_octet.stdout }}
+clientName = {{ env_splunk_group_name }}-{{ env|upper }}-{{ cf_app_tag_key_layer|upper }}
 
 [target-broker:deploymentServer]
 targetUri={{ splunk_target_server }}:{{ splunk_target_port }}

--- a/terraform/dev/backend.tf
+++ b/terraform/dev/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    region = "us-east-1"
+  }
+}

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -1,0 +1,107 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+##
+# Data providers
+##
+data "aws_vpc" "selected" {
+  id = "${var.vpc_id}"
+}
+
+data "aws_subnet_ids" "app" {
+  vpc_id = "${var.vpc_id}"
+
+  tags {
+    Layer       = "app"
+    stack       = "${var.stack}"
+    application = "${var.app}"
+  }
+}
+
+data "aws_subnet" "app" {
+  count = "${length(data.aws_subnet_ids.app.ids)}"
+  id    = "${data.aws_subnet_ids.app.ids[count.index]}"
+}
+
+data "aws_elb" "elb" {
+  name = "${var.elb_name}"
+}
+
+##
+# Security groups
+##
+resource "aws_security_group" "ci" {
+  name        = "ci-to-app-servers"
+  description = "Allow CI access to app servers"
+  vpc_id      = "${data.aws_vpc.selected.id}"
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["${var.ci_cidrs}"]
+  }
+}
+
+##
+# Launch configuration
+##
+resource "aws_launch_configuration" "app" {
+  security_groups = [
+    "${var.app_sg_id}",
+    "${var.vpn_sg_id}",
+    "${aws_security_group.ci.id}",
+  ]
+
+  key_name                    = "${var.key_name}"
+  image_id                    = "${var.ami_id}"
+  instance_type               = "${var.instance_type}"
+  associate_public_ip_address = false
+  name_prefix                 = "bb-${var.stack}-app-"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+##
+# Autoscaling group
+##
+resource "aws_autoscaling_group" "main" {
+  availability_zones        = ["${var.azs}"]
+  name                      = "bb-${var.stack}-app-${aws_launch_configuration.app.name}"
+  desired_capacity          = "${var.asg_desired}"
+  max_size                  = "${var.asg_max}"
+  min_size                  = "${var.asg_min}"
+  min_elb_capacity          = 1
+  health_check_grace_period = 300
+  health_check_type         = "ELB"
+  vpc_zone_identifier       = ["${data.aws_subnet_ids.app.ids}"]
+  launch_configuration      = "${aws_launch_configuration.app.name}"
+  load_balancers            = ["${data.aws_elb.elb.name}"]
+
+  tag {
+    key                 = "Name"
+    value               = "bb-${var.stack}-app"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Environment"
+    value               = "${var.env}"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Function"
+    value               = "app-AppServer"
+    propagate_at_launch = true
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# TODO(rnagle): autoscaling policy

--- a/terraform/dev/variables.tf
+++ b/terraform/dev/variables.tf
@@ -1,0 +1,33 @@
+variable "app" {}
+
+variable "stack" {}
+
+variable "env" {}
+
+variable "vpc_id" {}
+
+variable "key_name" {}
+
+variable "ami_id" {}
+
+variable "instance_type" {}
+
+variable "elb_name" {}
+
+variable "app_sg_id" {}
+
+variable "vpn_sg_id" {}
+
+variable "asg_min" {}
+
+variable "asg_max" {}
+
+variable "asg_desired" {}
+
+variable "azs" {
+  type = "list"
+}
+
+variable "ci_cidrs" {
+  type = "list"
+}


### PR DESCRIPTION
- Adds `playbook/build_ami` -- this basically combines the operations from `appherd/100_create_appserver.yml` and `appherd/200_build_appserver.yml` into a single playbook. Instead of adding the server to a load balancer at the end of the process, it stops the instance and creates an AMI based on it.
- Adds terraform configurations for ASG and launch configs to test AMI deployment in the dev environment
- Adds `Jenkinsfiles/build_ami` and `Jenkinsfiles/deploy_ami`