### PR TITLE
CBBP-892 CBBP-897 DRY terraform configs, add django management commands to deploy job

### DIFF
--- a/Jenkinsfiles/Jenkinsfile.deploy_ami
+++ b/Jenkinsfiles/Jenkinsfile.deploy_ami
@@ -1,4 +1,6 @@
 def aws_creds = 'cbj-deploy'
+def private_key = 'dev-key'
+def vault_pass = 'vault-pass'
 def backend_config = ''
 def terraform_vars = ''
 
@@ -30,6 +32,16 @@ pipeline {
       choices: 'dev\ntest\nimpl\nprod',
       description: 'The environment to deploy to. Required.',
       name: 'ENV'
+    )
+    choice(
+      choices: 'no\nyes',
+      description: 'Should we run database migrations on deploy?',
+      name: 'MIGRATE'
+    )
+    choice(
+      choices: 'yes\nno',
+      description: 'Should we run collectstatic on deploy?',
+      name: 'COLLECT_STATIC'
     )
   }
 
@@ -90,6 +102,38 @@ pipeline {
             url: 'https://github.com/CMSgov/bluebutton-web-deployment.git'
           ]]
         ])
+      }
+    }
+
+    stage('Install requirements') {
+      steps {
+        dir('code') {
+          script {
+            sh """
+              virtualenv -ppython2.7 venv
+              . venv/bin/activate
+
+              pip install --upgrade pip
+              pip install --upgrade cffi
+
+              pip install ansible==2.4.2.0
+              pip install boto
+            """
+          }
+        }
+      }
+    }
+
+    stage('Set private key file') {
+      steps {
+        script {
+            private_key = 'prod-key'
+        }
+      }
+      when {
+        expression {
+          params.ENV == "prod"
+        }
       }
     }
 
@@ -177,6 +221,42 @@ pipeline {
               }
             }
           }
+        }
+      }
+    }
+
+    stage('Django - migrate and collectstatic') {
+      steps {
+        script {
+          dir('code') {
+            withAwsCli(credentialsId: aws_creds, defaultRegion: 'us-east-1') {
+              withCredentials([
+                file(credentialsId: private_key, variable: 'pk'),
+                file(credentialsId: vault_pass, variable: 'vp')
+              ]) {
+                sh """
+                  . venv/bin/activate
+
+                  rm -Rf ./tmp
+
+                  EC2_INI_PATH=inventory/config/${params.ENV}.ini \
+                  ansible-playbook playbook/django/main.yml \
+                    --vault-password-file ${vp} \
+                    --private-key ${pk} \
+                    -i inventory/ec2.py \
+                    -l 'tag_Function_app_AppServer' \
+                    -e 'env=${params.ENV}' \
+                    -e 'collectstatic=${params.COLLECT_STATIC}' \
+                    -e 'migrate=${params.MIGRATE}'
+                """
+              }
+            }
+          }
+        }
+      }
+      when {
+        expression {
+          params.COLLECT_STATIC == "yes" || params.MIGRATE == "yes"
         }
       }
     }

--- a/Jenkinsfiles/Jenkinsfile.deploy_ami
+++ b/Jenkinsfiles/Jenkinsfile.deploy_ami
@@ -45,6 +45,14 @@ pipeline {
       }
     }
 
+    stage('Clear the working dir') {
+      steps {
+        dir('code') {
+          deleteDir()
+        }
+      }
+    }
+
     stage('Notify HipChat') {
       steps {
         withCredentials([
@@ -131,7 +139,7 @@ pipeline {
                   TF_ASG_CHECK=\$(echo "\$TF_OUT" | grep "aws_autoscaling_group.main")
                   TF_LC_CHECK=\$(echo "\$TF_OUT" | grep "aws_launch_configuration.app")
                   TF_AMI_CHECK=\$(echo "\$TF_OUT" | grep "image_id:.*(forces new resource)")
-                  TF_PLAN_CHECK=\$(echo "\$TF_OUT" | grep "Plan: 2 to add, 0 to change, 2 to destroy.")
+                  TF_PLAN_CHECK=\$(echo "\$TF_OUT" | grep "Plan: 4 to add, 2 to change, 4 to destroy.")
 
                   if [ -z "\$TF_ASG_CHECK" ] || [ -z "\$TF_LC_CHECK" ] || [ -z "\$TF_AMI_CHECK" ] || [ -z "\$TF_PLAN_CHECK" ]
                   then

--- a/Jenkinsfiles/Jenkinsfile.deploy_ami
+++ b/Jenkinsfiles/Jenkinsfile.deploy_ami
@@ -49,7 +49,7 @@ pipeline {
     stage('Ensure ENV and AMI_ID') {
       steps {
         sh """
-        if [ -z "${params.BRANCH}" ] || [ -z "${params.ENV}" ] || [ -z "${params.AMI_ID}" ] || [ -z "${params.SUBNET_ID}" ]
+        if [ -z "${params.ENV}" ] || [ -z "${params.AMI_ID}" ]
         then
           exit 1
         fi

--- a/playbook/appherd/roles/django_prep/tasks/main.yml
+++ b/playbook/appherd/roles/django_prep/tasks/main.yml
@@ -27,17 +27,6 @@
     virtualenv: "{{ venv }}"
   when: ( add_groups is defined ) and ( add_groups|lower == 'yes' )
 
-#- name: "Add Scopes to database"
-#  become_user: "{{ remote_admin_account }}"
-#  become: yes
-#  run_once: yes
-#  django_manage:
-#    command: loaddata apps/accounts/fixtures/scopes.json
-#    app_path: "{{ install_root }}/{{ project_name }}/"
-#    virtualenv: "{{ venv }}"
-#  when: ( add_scopes is defined ) and ( add_scopes|lower == 'yes' )
-
-
 ############################################################
 #
 # If you re-run the create_blue_button_scopes command
@@ -55,7 +44,6 @@
     app_path: "{{ install_root }}/{{ project_name }}/"
     virtualenv: "{{ venv }}"
   when: ( add_scopes is defined ) and ( add_scopes|lower == 'yes' )
-
 
 - name: "Load ResourceRouter and SupportedResourceType tables"
   become_user: "{{ remote_admin_account }}"
@@ -77,4 +65,3 @@
     virtualenv: "{{ venv }}"
   when: ( collectstatic is undefined ) or
         (( collectstatic is defined ) and ( collectstatic|lower == 'yes' ))
-

--- a/playbook/build_ami/main.yml
+++ b/playbook/build_ami/main.yml
@@ -173,6 +173,12 @@
           Environment: "{{ env|upper }}"
           Function: "{{ cf_app_tag_key_layer }}-AppServer"
           Layer:  "{{ cf_app_tag_key_layer|upper }}"
+      register: new_ami
+      delegate_to: localhost
+
+    - name: "Output new AMI ID"
+      debug:
+        msg: "{{ new_ami.image_id }}"
       delegate_to: localhost
 
     - name: "Terminate the build server"

--- a/playbook/django/main.yml
+++ b/playbook/django/main.yml
@@ -1,0 +1,19 @@
+---
+- name: Django Management (migrate, collectstatic)
+  hosts: all
+  remote_user: ec2-user
+  gather_facts: True
+  vars:
+    ansible_ssh_pipelining: no
+    env: "test"
+    migrate: "yes"
+    collectstatic: "yes"
+  vars_files:
+    - "./../../vars/common.yml"
+    - "./../../vault/env/{{ env }}/vault.yml"
+    - "./../../vars/env/{{ env }}/env.yml"
+    - "./../../vars/all_var.yml"
+
+  roles:
+    # django migrate and collectstatic
+    - ../appherd/roles/django_prep

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -21,3 +21,14 @@ module "asg" {
   app_sg_id     = "${var.app_sg_id}"
   vpn_sg_id     = "${var.vpn_sg_id}"
 }
+
+resource "aws_sns_topic" "cloudwatch_alarms_topic" {
+  name = "bluebutton-${var.stack}-cloudwatch-alarms"
+}
+
+module "cloudwatch_alarms" {
+  source                      = "../modules/elb_alarms"
+  vpc_name                    = "${var.vpc_id}"
+  cloudwatch_notification_arn = "${aws_sns_topic.cloudwatch_alarms_topic.arn}"
+  load_balancer_name          = "${var.elb_name}"
+}

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -2,106 +2,22 @@ provider "aws" {
   region = "us-east-1"
 }
 
-##
-# Data providers
-##
-data "aws_vpc" "selected" {
-  id = "${var.vpc_id}"
+module "asg" {
+  source = "../modules/asg"
+
+  app           = "${var.app}"
+  stack         = "${var.stack}"
+  env           = "${var.env}"
+  vpc_id        = "${var.vpc_id}"
+  key_name      = "${var.key_name}"
+  ami_id        = "${var.ami_id}"
+  instance_type = "${var.instance_type}"
+  elb_name      = "${var.elb_name}"
+  asg_min       = "${var.asg_min}"
+  asg_max       = "${var.asg_max}"
+  asg_desired   = "${var.asg_desired}"
+  azs           = ["${var.azs}"]
+  ci_cidrs      = ["${var.ci_cidrs}"]
+  app_sg_id     = "${var.app_sg_id}"
+  vpn_sg_id     = "${var.vpn_sg_id}"
 }
-
-data "aws_subnet_ids" "app" {
-  vpc_id = "${var.vpc_id}"
-
-  tags {
-    Layer       = "app"
-    stack       = "${var.stack}"
-    application = "${var.app}"
-  }
-}
-
-data "aws_subnet" "app" {
-  count = "${length(data.aws_subnet_ids.app.ids)}"
-  id    = "${data.aws_subnet_ids.app.ids[count.index]}"
-}
-
-data "aws_elb" "elb" {
-  name = "${var.elb_name}"
-}
-
-##
-# Security groups
-##
-resource "aws_security_group" "ci" {
-  name        = "ci-to-app-servers"
-  description = "Allow CI access to app servers"
-  vpc_id      = "${data.aws_vpc.selected.id}"
-
-  ingress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = ["${var.ci_cidrs}"]
-  }
-}
-
-##
-# Launch configuration
-##
-resource "aws_launch_configuration" "app" {
-  security_groups = [
-    "${var.app_sg_id}",
-    "${var.vpn_sg_id}",
-    "${aws_security_group.ci.id}",
-  ]
-
-  key_name                    = "${var.key_name}"
-  image_id                    = "${var.ami_id}"
-  instance_type               = "${var.instance_type}"
-  associate_public_ip_address = false
-  name_prefix                 = "bb-${var.stack}-app-"
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-##
-# Autoscaling group
-##
-resource "aws_autoscaling_group" "main" {
-  availability_zones        = ["${var.azs}"]
-  name                      = "bb-${var.stack}-app-${aws_launch_configuration.app.name}"
-  desired_capacity          = "${var.asg_desired}"
-  max_size                  = "${var.asg_max}"
-  min_size                  = "${var.asg_min}"
-  min_elb_capacity          = 1
-  health_check_grace_period = 300
-  health_check_type         = "ELB"
-  vpc_zone_identifier       = ["${data.aws_subnet_ids.app.ids}"]
-  launch_configuration      = "${aws_launch_configuration.app.name}"
-  load_balancers            = ["${data.aws_elb.elb.name}"]
-
-  tag {
-    key                 = "Name"
-    value               = "bb-${var.stack}-app"
-    propagate_at_launch = true
-  }
-
-  tag {
-    key                 = "Environment"
-    value               = "${var.env}"
-    propagate_at_launch = true
-  }
-
-  tag {
-    key                 = "Function"
-    value               = "app-AppServer"
-    propagate_at_launch = true
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-# TODO(rnagle): autoscaling policy

--- a/terraform/impl/backend.tf
+++ b/terraform/impl/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    region = "us-east-1"
+  }
+}

--- a/terraform/impl/main.tf
+++ b/terraform/impl/main.tf
@@ -21,3 +21,14 @@ module "asg" {
   app_sg_id     = "${var.app_sg_id}"
   vpn_sg_id     = "${var.vpn_sg_id}"
 }
+
+resource "aws_sns_topic" "cloudwatch_alarms_topic" {
+  name = "bluebutton-${var.stack}-cloudwatch-alarms"
+}
+
+module "cloudwatch_alarms" {
+  source                      = "../modules/elb_alarms"
+  vpc_name                    = "${var.vpc_id}"
+  cloudwatch_notification_arn = "${aws_sns_topic.cloudwatch_alarms_topic.arn}"
+  load_balancer_name          = "${var.elb_name}"
+}

--- a/terraform/impl/main.tf
+++ b/terraform/impl/main.tf
@@ -1,0 +1,23 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+module "asg" {
+  source = "../modules/asg"
+
+  app           = "${var.app}"
+  stack         = "${var.stack}"
+  env           = "${var.env}"
+  vpc_id        = "${var.vpc_id}"
+  key_name      = "${var.key_name}"
+  ami_id        = "${var.ami_id}"
+  instance_type = "${var.instance_type}"
+  elb_name      = "${var.elb_name}"
+  asg_min       = "${var.asg_min}"
+  asg_max       = "${var.asg_max}"
+  asg_desired   = "${var.asg_desired}"
+  azs           = ["${var.azs}"]
+  ci_cidrs      = ["${var.ci_cidrs}"]
+  app_sg_id     = "${var.app_sg_id}"
+  vpn_sg_id     = "${var.vpn_sg_id}"
+}

--- a/terraform/impl/variables.tf
+++ b/terraform/impl/variables.tf
@@ -1,0 +1,33 @@
+variable "app" {}
+
+variable "stack" {}
+
+variable "env" {}
+
+variable "vpc_id" {}
+
+variable "key_name" {}
+
+variable "ami_id" {}
+
+variable "instance_type" {}
+
+variable "elb_name" {}
+
+variable "app_sg_id" {}
+
+variable "vpn_sg_id" {}
+
+variable "asg_min" {}
+
+variable "asg_max" {}
+
+variable "asg_desired" {}
+
+variable "azs" {
+  type = "list"
+}
+
+variable "ci_cidrs" {
+  type = "list"
+}

--- a/terraform/modules/asg/main.tf
+++ b/terraform/modules/asg/main.tf
@@ -1,0 +1,156 @@
+##
+# Data providers
+##
+data "aws_vpc" "selected" {
+  id = "${var.vpc_id}"
+}
+
+data "aws_subnet_ids" "app" {
+  vpc_id = "${var.vpc_id}"
+
+  tags {
+    Layer       = "app"
+    stack       = "${var.stack}"
+    application = "${var.app}"
+  }
+}
+
+data "aws_subnet" "app" {
+  count = "${length(data.aws_subnet_ids.app.ids)}"
+  id    = "${data.aws_subnet_ids.app.ids[count.index]}"
+}
+
+data "aws_elb" "elb" {
+  name = "${var.elb_name}"
+}
+
+##
+# Security groups
+##
+resource "aws_security_group" "ci" {
+  name        = "ci-to-app-servers"
+  description = "Allow CI access to app servers"
+  vpc_id      = "${data.aws_vpc.selected.id}"
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["${var.ci_cidrs}"]
+  }
+}
+
+##
+# Launch configuration
+##
+resource "aws_launch_configuration" "app" {
+  security_groups = [
+    "${var.app_sg_id}",
+    "${var.vpn_sg_id}",
+    "${aws_security_group.ci.id}",
+  ]
+
+  key_name                    = "${var.key_name}"
+  image_id                    = "${var.ami_id}"
+  instance_type               = "${var.instance_type}"
+  associate_public_ip_address = false
+  name_prefix                 = "bb-${var.stack}-app-"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+##
+# Autoscaling group
+##
+resource "aws_autoscaling_group" "main" {
+  availability_zones        = ["${var.azs}"]
+  name                      = "bb-${var.stack}-app-${aws_launch_configuration.app.name}"
+  desired_capacity          = "${var.asg_desired}"
+  max_size                  = "${var.asg_max}"
+  min_size                  = "${var.asg_min}"
+  min_elb_capacity          = 1
+  health_check_grace_period = 300
+  health_check_type         = "ELB"
+  vpc_zone_identifier       = ["${data.aws_subnet_ids.app.ids}"]
+  launch_configuration      = "${aws_launch_configuration.app.name}"
+  load_balancers            = ["${data.aws_elb.elb.name}"]
+
+  tag {
+    key                 = "Name"
+    value               = "bb-${var.stack}-app"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Environment"
+    value               = "${var.env}"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Function"
+    value               = "app-AppServer"
+    propagate_at_launch = true
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+##
+# Autoscaling policies and Cloudwatch alarms
+##
+resource "aws_autoscaling_policy" "high-cpu" {
+  name                   = "${var.app}-${var.env}-high-cpu-scaleup"
+  scaling_adjustment     = 2
+  adjustment_type        = "ChangeInCapacity"
+  cooldown               = 300
+  autoscaling_group_name = "${aws_autoscaling_group.main.name}"
+}
+
+resource "aws_cloudwatch_metric_alarm" "high-cpu" {
+  alarm_name          = "${var.app}-${var.env}-high-cpu"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = "120"
+  statistic           = "Average"
+  threshold           = "60"
+
+  dimensions {
+    AutoScalingGroupName = "${aws_autoscaling_group.main.name}"
+  }
+
+  alarm_description = "CPU usage for ${aws_autoscaling_group.main.name} ASG"
+  alarm_actions     = ["${aws_autoscaling_policy.high-cpu.arn}"]
+}
+
+resource "aws_autoscaling_policy" "low-cpu" {
+  name                   = "${var.app}-${var.env}-low-cpu-scaledown"
+  scaling_adjustment     = -1
+  adjustment_type        = "ChangeInCapacity"
+  cooldown               = 300
+  autoscaling_group_name = "${aws_autoscaling_group.main.name}"
+}
+
+resource "aws_cloudwatch_metric_alarm" "low-cpu" {
+  alarm_name          = "${var.app}-${var.env}-low-cpu"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = "120"
+  statistic           = "Average"
+  threshold           = "20"
+
+  dimensions {
+    AutoScalingGroupName = "${aws_autoscaling_group.main.name}"
+  }
+
+  alarm_description = "CPU usage for ${aws_autoscaling_group.main.name} ASG"
+  alarm_actions     = ["${aws_autoscaling_policy.low-cpu.arn}"]
+}

--- a/terraform/modules/asg/main.tf
+++ b/terraform/modules/asg/main.tf
@@ -70,7 +70,7 @@ resource "aws_autoscaling_group" "main" {
   desired_capacity          = "${var.asg_desired}"
   max_size                  = "${var.asg_max}"
   min_size                  = "${var.asg_min}"
-  min_elb_capacity          = 1
+  min_elb_capacity          = "${var.asg_min}"
   health_check_grace_period = 300
   health_check_type         = "ELB"
   vpc_zone_identifier       = ["${data.aws_subnet_ids.app.ids}"]

--- a/terraform/modules/asg/variables.tf
+++ b/terraform/modules/asg/variables.tf
@@ -1,0 +1,33 @@
+variable "app" {}
+
+variable "stack" {}
+
+variable "env" {}
+
+variable "vpc_id" {}
+
+variable "key_name" {}
+
+variable "ami_id" {}
+
+variable "instance_type" {}
+
+variable "elb_name" {}
+
+variable "app_sg_id" {}
+
+variable "vpn_sg_id" {}
+
+variable "asg_min" {}
+
+variable "asg_max" {}
+
+variable "asg_desired" {}
+
+variable "azs" {
+  type = "list"
+}
+
+variable "ci_cidrs" {
+  type = "list"
+}

--- a/terraform/modules/elb_alarms/README.md
+++ b/terraform/modules/elb_alarms/README.md
@@ -1,0 +1,9 @@
+# Terraform Compatible ELB Cloudwatch Alarms Module
+
+This module should create Cloudwatch Alarms for an existing ELB.
+
+See the [top level README](../README.md) for more details.
+
+## Usage
+
+See [../README.md#terraform-usage](../README.md#terraform-usage).

--- a/terraform/modules/elb_alarms/fixture/main.tf
+++ b/terraform/modules/elb_alarms/fixture/main.tf
@@ -1,0 +1,94 @@
+# Test fixture for kitchen-terraform
+#
+# This configuration is what kitchen-terraform runs against, so here you can
+# define any resources that your module depends on as well as your module itself
+# so that it can all be set up automatically.
+
+provider "aws" {
+  region = "${var.aws_region}"
+}
+
+terraform {
+  backend "s3" {}
+}
+
+# Test harness variables
+#
+# These are automatically set by the test boilerplate, and can be used or not
+# used by the module being tested.
+variable "vpc_name" {
+  description = "The name of the temporary test vpc"
+}
+
+variable "environment_name" {
+  description = "The name of the temporary test environment"
+}
+
+variable "aws_region" {
+  description = "The region to deploy to"
+  default     = "us-east-1"
+}
+
+resource "aws_sns_topic" "alarm_topic" {
+  name = "${var.vpc_name}"
+}
+
+resource "aws_vpc" "base" {
+  cidr_block = "10.0.0.0/16"
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_subnet" "base" {
+  count             = 2
+  vpc_id            = "${aws_vpc.base.id}"
+  cidr_block        = "10.0.${count.index}.0/24"
+  availability_zone = "${data.aws_availability_zones.available.names[count.index]}"
+}
+
+resource "aws_security_group" "allow_all" {
+  name        = "${var.vpc_name}"
+  vpc_id      = "${aws_vpc.base.id}"
+  description = "Allow all inbound traffic"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    Name = "${var.vpc_name}"
+  }
+}
+
+resource "aws_elb" "alarmed_balancer" {
+  name            = "terraform-harness-load-balancer"
+  subnets         = ["${aws_subnet.base.*.id}"]
+  security_groups = ["${aws_security_group.allow_all.id}"]
+  internal        = true
+
+  listener {
+    instance_port     = 80
+    instance_protocol = "http"
+    lb_port           = 80
+    lb_protocol       = "http"
+  }
+
+  tags {
+    created_by = "terraform-harness"
+    vpc_name   = "${var.vpc_name}"
+  }
+}
+
+module "cloudwatch_alarms" {
+  # Here you can use "../../../test-module" to pull in the module from the local
+  # directory.  Remember that it needs to be relative to where test kitchen
+  # copies this fixture, which is in ".kitchen".
+  source = "../../../test-module"
+
+  vpc_name                    = "${var.vpc_name}"
+  cloudwatch_notification_arn = "${aws_sns_topic.alarm_topic.arn}"
+  load_balancer_name          = "${aws_elb.alarmed_balancer.name}"
+}

--- a/terraform/modules/elb_alarms/main.tf
+++ b/terraform/modules/elb_alarms/main.tf
@@ -1,0 +1,100 @@
+##
+#
+# NOTE: this module was copied from https://github.com/CMSgov/tf-elb-alarms.
+#
+# It's not publicly available as of yet. Please avoid making modifications to this module directly to ensure migration to the public module is possible at a later date.
+#
+# Contact @rnagle or @sverchdotgov with questions.
+#
+##
+resource "aws_cloudwatch_metric_alarm" "healthy_hosts" {
+  alarm_name          = "${var.load_balancer_name}-elb-no-backend"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "HealthyHostCount"
+  namespace           = "AWS/ELB"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "${var.cloudwatch_healthy_hosts_min}"
+  alarm_description   = "No backends available for ${var.load_balancer_name} in ${var.vpc_name}"
+
+  dimensions {
+    LoadBalancerName = "${var.load_balancer_name}"
+  }
+
+  # We should always have a measure of the number of healthy hosts - alert if not
+  treat_missing_data = "breaching"
+  alarm_actions      = ["${var.cloudwatch_notification_arn}"]
+  ok_actions         = ["${var.cloudwatch_notification_arn}"]
+}
+
+resource "aws_cloudwatch_metric_alarm" "high_latency" {
+  alarm_name          = "elb-${var.load_balancer_name}-high-latency"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "Latency"
+  namespace           = "AWS/ELB"
+  period              = "${var.cloudwatch_max_latency_window_secs}"
+  statistic           = "Average"
+
+  dimensions {
+    LoadBalancerName = "${var.load_balancer_name}"
+  }
+
+  threshold         = "${var.cloudwatch_max_latency_secs}"
+  unit              = "Seconds"
+  alarm_description = "High latency for ELB ${var.load_balancer_name} in ${var.vpc_name}."
+
+  # "Missing data" means that we haven't had any measure of latency - alert if we don't
+  treat_missing_data = "breaching"
+  alarm_actions      = ["${var.cloudwatch_notification_arn}"]
+  ok_actions         = ["${var.cloudwatch_notification_arn}"]
+}
+
+resource "aws_cloudwatch_metric_alarm" "spillover_count" {
+  alarm_name          = "elb-${var.load_balancer_name}-spillover-count"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "SpilloverCount"
+  namespace           = "AWS/ELB"
+  period              = "60"
+  statistic           = "Maximum"
+
+  dimensions {
+    LoadBalancerName = "${var.load_balancer_name}"
+  }
+
+  threshold         = "3"
+  unit              = "Count"
+  alarm_description = "Spillover alarm for ELB ${var.load_balancer_name} in ${var.vpc_name}. Add nodes."
+
+  # A missing spillover count means that we haven't spillover - that's good! Don't alert.
+  treat_missing_data = "notBreaching"
+  alarm_actions      = ["${var.cloudwatch_notification_arn}"]
+  ok_actions         = ["${var.cloudwatch_notification_arn}"]
+}
+
+resource "aws_cloudwatch_metric_alarm" "surge_queue_exceeded" {
+  alarm_name          = "elb-${var.load_balancer_name}-surge-queue-length"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "3"
+  metric_name         = "SurgeQueueLength"
+  namespace           = "AWS/ELB"
+  period              = "60"
+  statistic           = "Maximum"
+
+  dimensions {
+    LoadBalancerName = "${var.load_balancer_name}"
+  }
+
+  threshold         = "300"
+  unit              = "Count"
+  alarm_description = "Surge queue exceeded for ELB ${var.load_balancer_name} in ${var.vpc_name}. Add nodes."
+
+  # An undefined surge queue length is good - we haven't had to queue any requests recently, so
+  # don't alert
+  treat_missing_data = "notBreaching"
+
+  alarm_actions = ["${var.cloudwatch_notification_arn}"]
+  ok_actions    = ["${var.cloudwatch_notification_arn}"]
+}

--- a/terraform/modules/elb_alarms/variables.tf
+++ b/terraform/modules/elb_alarms/variables.tf
@@ -1,0 +1,32 @@
+variable "vpc_name" {
+  description = "Name of the VPC these alarms are for."
+  type        = "string"
+}
+
+variable "load_balancer_name" {
+  description = "Name of the ELB these alarms are for."
+  type        = "string"
+}
+
+variable "cloudwatch_healthy_hosts_min" {
+  description = "Minimum number of hosts that must be healthy."
+  type        = "string"
+  default     = "1"
+}
+
+variable "cloudwatch_max_latency_secs" {
+  description = "Maximum average latency threshold."
+  type        = "string"
+  default     = "2"
+}
+
+variable "cloudwatch_max_latency_window_secs" {
+  description = "Maximum average latency average window size in seconds."
+  type        = "string"
+  default     = "900"
+}
+
+variable "cloudwatch_notification_arn" {
+  description = "The CloudWatch notification ARN."
+  type        = "string"
+}

--- a/terraform/prod/backend.tf
+++ b/terraform/prod/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    region = "us-east-1"
+  }
+}

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -21,3 +21,14 @@ module "asg" {
   app_sg_id     = "${var.app_sg_id}"
   vpn_sg_id     = "${var.vpn_sg_id}"
 }
+
+resource "aws_sns_topic" "cloudwatch_alarms_topic" {
+  name = "bluebutton-${var.stack}-cloudwatch-alarms"
+}
+
+module "cloudwatch_alarms" {
+  source                      = "../modules/elb_alarms"
+  vpc_name                    = "${var.vpc_id}"
+  cloudwatch_notification_arn = "${aws_sns_topic.cloudwatch_alarms_topic.arn}"
+  load_balancer_name          = "${var.elb_name}"
+}

--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -1,0 +1,23 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+module "asg" {
+  source = "../modules/asg"
+
+  app           = "${var.app}"
+  stack         = "${var.stack}"
+  env           = "${var.env}"
+  vpc_id        = "${var.vpc_id}"
+  key_name      = "${var.key_name}"
+  ami_id        = "${var.ami_id}"
+  instance_type = "${var.instance_type}"
+  elb_name      = "${var.elb_name}"
+  asg_min       = "${var.asg_min}"
+  asg_max       = "${var.asg_max}"
+  asg_desired   = "${var.asg_desired}"
+  azs           = ["${var.azs}"]
+  ci_cidrs      = ["${var.ci_cidrs}"]
+  app_sg_id     = "${var.app_sg_id}"
+  vpn_sg_id     = "${var.vpn_sg_id}"
+}

--- a/terraform/prod/variables.tf
+++ b/terraform/prod/variables.tf
@@ -1,0 +1,33 @@
+variable "app" {}
+
+variable "stack" {}
+
+variable "env" {}
+
+variable "vpc_id" {}
+
+variable "key_name" {}
+
+variable "ami_id" {}
+
+variable "instance_type" {}
+
+variable "elb_name" {}
+
+variable "app_sg_id" {}
+
+variable "vpn_sg_id" {}
+
+variable "asg_min" {}
+
+variable "asg_max" {}
+
+variable "asg_desired" {}
+
+variable "azs" {
+  type = "list"
+}
+
+variable "ci_cidrs" {
+  type = "list"
+}

--- a/terraform/test/backend.tf
+++ b/terraform/test/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    region = "us-east-1"
+  }
+}

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -21,3 +21,14 @@ module "asg" {
   app_sg_id     = "${var.app_sg_id}"
   vpn_sg_id     = "${var.vpn_sg_id}"
 }
+
+resource "aws_sns_topic" "cloudwatch_alarms_topic" {
+  name = "bluebutton-${var.stack}-cloudwatch-alarms"
+}
+
+module "cloudwatch_alarms" {
+  source                      = "../modules/elb_alarms"
+  vpc_name                    = "${var.vpc_id}"
+  cloudwatch_notification_arn = "${aws_sns_topic.cloudwatch_alarms_topic.arn}"
+  load_balancer_name          = "${var.elb_name}"
+}

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -1,0 +1,23 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+module "asg" {
+  source = "../modules/asg"
+
+  app           = "${var.app}"
+  stack         = "${var.stack}"
+  env           = "${var.env}"
+  vpc_id        = "${var.vpc_id}"
+  key_name      = "${var.key_name}"
+  ami_id        = "${var.ami_id}"
+  instance_type = "${var.instance_type}"
+  elb_name      = "${var.elb_name}"
+  asg_min       = "${var.asg_min}"
+  asg_max       = "${var.asg_max}"
+  asg_desired   = "${var.asg_desired}"
+  azs           = ["${var.azs}"]
+  ci_cidrs      = ["${var.ci_cidrs}"]
+  app_sg_id     = "${var.app_sg_id}"
+  vpn_sg_id     = "${var.vpn_sg_id}"
+}

--- a/terraform/test/variables.tf
+++ b/terraform/test/variables.tf
@@ -1,0 +1,33 @@
+variable "app" {}
+
+variable "stack" {}
+
+variable "env" {}
+
+variable "vpc_id" {}
+
+variable "key_name" {}
+
+variable "ami_id" {}
+
+variable "instance_type" {}
+
+variable "elb_name" {}
+
+variable "app_sg_id" {}
+
+variable "vpn_sg_id" {}
+
+variable "asg_min" {}
+
+variable "asg_max" {}
+
+variable "asg_desired" {}
+
+variable "azs" {
+  type = "list"
+}
+
+variable "ci_cidrs" {
+  type = "list"
+}


### PR DESCRIPTION
- Refactors terraform configs, moving the ASG, LC and autoscaling policies to a reusable module (see: `terraform/modules/asg`).
- Adds a steps to the `deploy_ami` pipeline to handle Django `migrate` and `collectstatic` commands.