### PR TITLE
CBBP-927 Removing elb alarms from dev and test because they are noisy

### DIFF
--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -26,10 +26,3 @@ module "asg" {
   vpn_sg_id     = "${var.vpn_sg_id}"
   sns_topic_arn = "${aws_sns_topic.cloudwatch_alarms_topic.arn}"
 }
-
-module "cloudwatch_alarms" {
-  source                      = "../modules/elb_alarms"
-  vpc_name                    = "${var.vpc_id}"
-  cloudwatch_notification_arn = "${aws_sns_topic.cloudwatch_alarms_topic.arn}"
-  load_balancer_name          = "${var.elb_name}"
-}

--- a/terraform/dev/variables.tf
+++ b/terraform/dev/variables.tf
@@ -31,9 +31,3 @@ variable "azs" {
 variable "ci_cidrs" {
   type = "list"
 }
-
-variable "cloudwatch_max_latency_secs" {
-  description = "Maximum average latency threshold."
-  type        = "string"
-  default     = "2"
-}

--- a/terraform/dev/variables.tf
+++ b/terraform/dev/variables.tf
@@ -31,3 +31,9 @@ variable "azs" {
 variable "ci_cidrs" {
   type = "list"
 }
+
+variable "cloudwatch_max_latency_secs" {
+  description = "Maximum average latency threshold."
+  type        = "string"
+  default     = "2"
+}

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -26,10 +26,3 @@ module "asg" {
   vpn_sg_id     = "${var.vpn_sg_id}"
   sns_topic_arn = "${aws_sns_topic.cloudwatch_alarms_topic.arn}"
 }
-
-module "cloudwatch_alarms" {
-  source                      = "../modules/elb_alarms"
-  vpc_name                    = "${var.vpc_id}"
-  cloudwatch_notification_arn = "${aws_sns_topic.cloudwatch_alarms_topic.arn}"
-  load_balancer_name          = "${var.elb_name}"
-}

--- a/terraform/test/variables.tf
+++ b/terraform/test/variables.tf
@@ -31,3 +31,10 @@ variable "azs" {
 variable "ci_cidrs" {
   type = "list"
 }
+
+variable "cloudwatch_max_latency_secs" {
+  description = "Maximum average latency threshold."
+  type        = "string"
+  default     = "2"
+}
+

--- a/terraform/test/variables.tf
+++ b/terraform/test/variables.tf
@@ -32,9 +32,3 @@ variable "ci_cidrs" {
   type = "list"
 }
 
-variable "cloudwatch_max_latency_secs" {
-  description = "Maximum average latency threshold."
-  type        = "string"
-  default     = "2"
-}
-


### PR DESCRIPTION
Alarms were removed from dev and test terraform configurations, since they were generating a lot of noise.
This was done by removing the elb_alarms module reference from the main.tf files. Left the variables.tf alone for future use.