### PR TITLE
CBBP-959 Add 'Release' tag to AMIs and to running app servers

### DIFF
--- a/Jenkinsfiles/Jenkinsfile.build_ami
+++ b/Jenkinsfiles/Jenkinsfile.build_ami
@@ -1,6 +1,7 @@
 def private_key = 'dev-key'
 def vault_pass = 'vault-pass'
 def aws_creds = 'cbj-deploy'
+def release_version = ''
 
 pipeline {
   agent {
@@ -52,6 +53,33 @@ pipeline {
           exit 1
         fi
         """
+      }
+    }
+
+    stage('Stop master and develop deployments to IMPL and PROD') {
+      steps {
+        sh """
+        if [ "${params.BRANCH}" == "master" ] || [ "${params.BRANCH}" == "develop" ]
+        then
+          if [ "${params.ENV}" == "impl" ] || [ "${params.ENV}" == "prod" ]
+          then
+            exit 1
+          fi
+        fi
+        """
+      }
+    }
+
+    stage('Set release_version var') {
+      steps {
+        script {
+          if (params.BRANCH == 'develop' || params.BRANCH == 'master') {
+            release_version = "latest-${params.BRANCH}"
+          } else {
+            # Git tag, committish or branch other than master, develop
+            release_version = "${params.BRANCH}"
+          }
+        }
       }
     }
 
@@ -146,7 +174,8 @@ pipeline {
                     -e 'env=${params.ENV}' \
                     -e 'cf_app_instance_type=${params.INSTANCE_CLASS}' \
                     -e 'build_subnet_id=${params.SUBNET_ID}' \
-                    -e 'ami_app_gold_image=${params.AMI_ID}'
+                    -e 'ami_app_gold_image=${params.AMI_ID}' \
+                    -e 'release_version=${release_version}'
                 """
               }
             }

--- a/Jenkinsfiles/Jenkinsfile.build_ami
+++ b/Jenkinsfiles/Jenkinsfile.build_ami
@@ -76,7 +76,7 @@ pipeline {
           if (params.BRANCH == 'develop' || params.BRANCH == 'master') {
             release_version = "latest-${params.BRANCH}"
           } else {
-            # Git tag, committish or branch other than master, develop
+            // Git tag, committish or branch other than master, develop
             release_version = "${params.BRANCH}"
           }
         }

--- a/Jenkinsfiles/Jenkinsfile.deploy_ami
+++ b/Jenkinsfiles/Jenkinsfile.deploy_ami
@@ -184,7 +184,7 @@ pipeline {
                   TF_ASG_CHECK=\$(echo "\$TF_OUT" | grep "aws_autoscaling_group.main")
                   TF_LC_CHECK=\$(echo "\$TF_OUT" | grep "aws_launch_configuration.app")
                   TF_AMI_CHECK=\$(echo "\$TF_OUT" | grep "image_id:.*(forces new resource)")
-                  TF_PLAN_CHECK=\$(echo "\$TF_OUT" | grep "Plan: 4 to add, 2 to change, 4 to destroy.")
+                  TF_PLAN_CHECK=\$(echo "\$TF_OUT" | grep "Plan: 4 to add, 3 to change, 4 to destroy.")
 
                   if [ -z "\$TF_ASG_CHECK" ] || [ -z "\$TF_LC_CHECK" ] || [ -z "\$TF_AMI_CHECK" ] || [ -z "\$TF_PLAN_CHECK" ]
                   then

--- a/playbook/build_ami/main.yml
+++ b/playbook/build_ami/main.yml
@@ -112,8 +112,6 @@
     - name: Gather instance metadata
       ec2_metadata_facts:
 
-    - import_tasks: ../appherd/roles/create_superuser/tasks/main.yml
-
     - name: "Reboot the instance"
       shell: sleep 2 && /sbin/shutdown -r now
       async: 1

--- a/playbook/build_ami/main.yml
+++ b/playbook/build_ami/main.yml
@@ -173,6 +173,7 @@
           Environment: "{{ env|upper }}"
           Function: "{{ cf_app_tag_key_layer }}-AppServer"
           Layer:  "{{ cf_app_tag_key_layer|upper }}"
+          Release: "{{ release_version|default('none') }}"
       register: new_ami
       delegate_to: localhost
 

--- a/terraform/modules/asg/main.tf
+++ b/terraform/modules/asg/main.tf
@@ -24,6 +24,16 @@ data "aws_elb" "elb" {
   name = "${var.elb_name}"
 }
 
+data "aws_ami" "image" {
+  most_recent = true
+  owners      = ["self"]
+
+  filter {
+    name   = "image-id"
+    values = ["${var.ami_id}"]
+  }
+}
+
 ##
 # Security groups
 ##
@@ -97,6 +107,12 @@ resource "aws_autoscaling_group" "main" {
   tag {
     key                 = "Function"
     value               = "app-AppServer"
+    propagate_at_launch = true
+  }
+
+  tag {
+    key                 = "Release"
+    value               = "${lookup(data.aws_ami.image.tags, "Release", "none")}"
     propagate_at_launch = true
   }
 


### PR DESCRIPTION
What's included:

- Change AMI build so that it tags the image with value of `params.BRANCH` (which can be a git commit, tag or branch).
- Have terraform `asg` module lookup the new AMI and use the value for its `Release` tag to apply the same tag to running app servers.
- Prevents builds/deploys to IMPL or PROD with vague references `develop` or `master` which can make it difficult to see what's deployed at a glance.