### PR TITLE
CBBP-1023: Add /v1/fhir as variable to aws-{env}.py

### DIFF
--- a/playbook/appherd/roles/create_env_settings/templates/aws-env.py.j2
+++ b/playbook/appherd/roles/create_env_settings/templates/aws-env.py.j2
@@ -62,6 +62,9 @@ EMAIL_BACKEND ="{{ django_email_backend }}"
 APPLICATION_TITLE = "{{ django_app_title }}"
 
 HOSTNAME_URL = "{{ host_url }}"
+### Front-End FHIR API PATH - eg. /v1/fhir
+FHIR_API_PATH =  "{{ fhir_api_path_in }}"
+
 INVITE_REQUEST_ADMIN ='{{ django_admin_email }}'
 
 # Set to False in NON-PRODUCTION Environments

--- a/vars/all_var.yml
+++ b/vars/all_var.yml
@@ -141,6 +141,8 @@
 
   ### HOSTNAME_URL:
   host_url: "{{ env_external_dns_name }}"
+  ### Front-End FHIR API PATH - eg. /v1/fhir
+  fhir_api_path_in: "{{ env_fhir_api_path_in }}"
 
   # django environment specific apps list
   django_environment_apps: "{{ env_django_environment_apps }}"

--- a/vars/env/dev/env.yml
+++ b/vars/env/dev/env.yml
@@ -105,6 +105,8 @@ env_django_signup_timeout_days: 7
 
 ### HOSTNAME_URL:
 env_host_url: "{{ env_external_dns_name }}"
+### Front-End FHIR API PATH - eg. /v1/fhir
+env_fhir_api_path_in: "/v1/fhir"
 
 # django environment specific apps list
 # A test client - moved to aws-test / dev /impl settings

--- a/vars/env/impl/env.yml
+++ b/vars/env/impl/env.yml
@@ -105,6 +105,8 @@ env_django_signup_timeout_days: 7
 
 ### HOSTNAME_URL:
 env_host_url: "{{ env_external_dns_name }}"
+### Front-End FHIR API PATH - eg. /v1/fhir
+env_fhir_api_path_in: "/v1/fhir"
 
 # django environment specific apps list
 # A test client - moved to aws-test / dev /impl settings

--- a/vars/env/prod/env.yml
+++ b/vars/env/prod/env.yml
@@ -88,6 +88,8 @@ env_static_root_dir: "static"
 ## PROD:
 # env_external_dns_name: "bluebutton.cms.gov"
 env_external_dns_name: "api.bluebutton.cms.gov"
+### Front-End FHIR API PATH - eg. /v1/fhir
+env_fhir_api_path_in: "/v1/fhir"
 
 ### TransparentHealthServer default settings:
 ## MiHIN TestServer:

--- a/vars/env/test/env.yml
+++ b/vars/env/test/env.yml
@@ -106,6 +106,8 @@ env_django_signup_timeout_days: 7
 
 ### HOSTNAME_URL:
 env_host_url: "{{ env_external_dns_name }}"
+### Front-End FHIR API PATH - eg. /v1/fhir
+env_fhir_api_path_in: "/v1/fhir"
 
 # django environment specific apps list
 # A test client - moved to aws-test / dev /impl settings


### PR DESCRIPTION
Allow set_default_headers to pass inbound base_uri to back-end.
ie Proto + :// + HOSTNAME_URL + FHIR_API_PATH
Enabling FHIR_API_PATH as a variable that can be changed per environment.
FHIR_API_PATH is the inbound base_uri for FHIR resources. eg. /v1/fhir