### PR TITLE
CBBP-1037 Fix error in "mark deployment" portion of deploy ami job

### DIFF
--- a/Jenkinsfiles/Jenkinsfile.deploy_ami
+++ b/Jenkinsfiles/Jenkinsfile.deploy_ami
@@ -287,8 +287,6 @@ pipeline {
             string(credentialsId: 'new-relic-api-key', variable: 'api_key'),
           ]) {
             sh """
-              . venv/bin/activate
-
               python ./lib/mark_deployment.py \
                 --app_id ${app_id} \
                 --api_key ${api_key} \


### PR DESCRIPTION
The `lib/mark_deployment.py` script uses only standard lib modules, so we don't need a virtualenv in order to execute it. This PR simply removes the `. venv/bin/activate` line, which was causing the error: `venv/bin/activate: No such file or directory` presumably because the virtualenv is cleaned up/removed by the time we reach the "post" portion of `Jenkinsfile.deploy_ami`.