### PR TITLE
Install mod_wsgi from pypi repo

### DIFF
--- a/playbook/appherd/roles/mod_wsgi/files/wsgi.conf
+++ b/playbook/appherd/roles/mod_wsgi/files/wsgi.conf
@@ -1,1 +1,0 @@
-LoadModule wsgi_module modules/mod_wsgi.so

--- a/playbook/appherd/roles/mod_wsgi/tasks/main.yml
+++ b/playbook/appherd/roles/mod_wsgi/tasks/main.yml
@@ -3,7 +3,7 @@
   become: yes
   become_user: "{{ remote_admin_account }}"
   shell: |
-   source {{ cf_app_py_virtual_env }}/bin/activate && pip install mod_wsgi
+   source {{ cf_app_py_virtual_env }}/bin/activate && pip install mod_wsgi==4.6.4
   environment:
     APXS: /bin/apxs
 

--- a/playbook/appherd/roles/mod_wsgi/tasks/main.yml
+++ b/playbook/appherd/roles/mod_wsgi/tasks/main.yml
@@ -7,6 +7,16 @@
   environment:
     APXS: /bin/apxs
 
+- name: "fix ownership of virtualenv"
+  become_user: "{{ remote_admin_account }}"
+  become: yes
+  file:
+    owner: "{{ cf_app_pyapps_user }}"
+    group: "{{ app_group }}"
+    dest: "{{ cf_app_py_virtual_env }}"
+    state: directory
+    recurse: yes
+
 - name: "capture wsgi configuration"
   become: yes
   become_user: "{{ remote_admin_account }}"

--- a/playbook/appherd/roles/mod_wsgi/tasks/main.yml
+++ b/playbook/appherd/roles/mod_wsgi/tasks/main.yml
@@ -18,7 +18,7 @@
   become_user: "{{ remote_admin_account }}"
   become: yes
   template:
-    src: "../templates/wsgi.conf"
+    src: "wsgi.conf.j2"
     dest: "/etc/httpd/conf.modules.d/10-wsgi.conf"
     owner: root
     group: root

--- a/playbook/appherd/roles/mod_wsgi/tasks/main.yml
+++ b/playbook/appherd/roles/mod_wsgi/tasks/main.yml
@@ -1,68 +1,25 @@
 ---
-# File: roles/python3/tasks/main.yml
-# Created: 5/10/17
-# Author: '@ekivemark'
-# download and install python3
+- name: "install mod_wsgi"
+  become: yes
+  become_user: "{{ remote_admin_account }}"
+  shell: |
+   source {{ cf_app_py_virtual_env }}/bin/activate && pip install mod_wsgi
+  environment:
+    APXS: /bin/apxs
 
-- name: "create download directory"
-  file:
-    dest: "/home/ec2-user/download"
-    state: directory
-    mode: 0600
-    owner: "ec2-user"
-    group: "ec2-user"
-  register: app_download_dir
+- name: "capture wsgi configuration"
+  become: yes
+  become_user: "{{ remote_admin_account }}"
+  shell: |
+    source {{ cf_app_py_virtual_env }}/bin/activate && mod_wsgi-express module-config
+  register: mod_wsgi_conf
 
-- name: "Download mod_wsgi_{{ mod_wsgi_ver_full }}"
+- name: "install wsgi.conf"
   become_user: "{{ remote_admin_account }}"
   become: yes
-  get_url:
-    url: "https://codeload.github.com/GrahamDumpleton/mod_wsgi/tar.gz/{{ mod_wsgi_ver_full }}"
-    dest: "/home/ec2-user/download/mod_wsgi_{{ mod_wsgi_ver_full }}.tar.gz"
-    remote_src: True
-
-- name: "Unarchive mod_wsgi_{{ mod_wsgi_ver_full }}"
-  become_user: "{{ remote_admin_account }}"
-  become: yes
-  shell: "cd /home/ec2-user/download ; /usr/bin/tar -xzvf /home/ec2-user/download/mod_wsgi_{{ mod_wsgi_ver_full }}.tar.gz ; cd /home/ec2-user/download/mod_wsgi-{{ mod_wsgi_ver_full }} "
-  register: mod_wsgi_info
-
-- name: "Running configure for mod_wsgi"
-  become_user: "{{ remote_admin_account }}"
-  become: yes
-  shell: "cd /home/ec2-user/download/mod_wsgi-{{ mod_wsgi_ver_full }} ; make clean ; make uninstall ; make -n install ; ./configure --with-python={{ python_bin_dir }}/python{{ python_ver }} --with-apxs=/usr/bin/apxs "
-
-- name: "Prepare to refresh ld cache"
-  become_user: "{{ remote_admin_account }}"
-  become: yes
-  lineinfile:
-    dest: "/etc/ld.so.conf"
-    line: "/usr/local/lib"
-    state: present
-
-- name: "Refresh LD Cache"
-  become_user: "{{ remote_admin_account }}"
-  become: yes
-  shell: "/sbin/ldconfig"
-
-- name: "Running make for mod_wsgi"
-  become_user: "{{ remote_admin_account }}"
-  become: yes
-  shell: "cd /home/ec2-user/download/mod_wsgi-{{ mod_wsgi_ver_full }} ; make "
-
-- name: "Running make install for mod_wsgi"
-  become_user: "{{ remote_admin_account }}"
-  become: yes
-  shell: "cd /home/ec2-user/download/mod_wsgi-{{ mod_wsgi_ver_full }} ; make install "
-
-- name: "Copy Wsgi Load Module instruction in to place"
-  become_user: "{{ remote_admin_account }}"
-  become: yes
-  copy:
-    src: "../files/wsgi.conf"
-    # rhel 7 apache 2.4 configuration
+  template:
+    src: "../templates/wsgi.conf"
     dest: "/etc/httpd/conf.modules.d/10-wsgi.conf"
     owner: root
     group: root
     mode: "0644"
-

--- a/playbook/appherd/roles/mod_wsgi/templates/wsgi.conf.j2
+++ b/playbook/appherd/roles/mod_wsgi/templates/wsgi.conf.j2
@@ -1,0 +1,1 @@
+{{ mod_wsgi_conf.stdout }}


### PR DESCRIPTION
Refactors the `mod_wsgi` role to simplify the install process.

The output from step `capture wsgi configuration` will look something like:

```
LoadModule wsgi_module "/venv/path/lib64/python3.4/site-packages/mod_wsgi/server/mod_wsgi-py34.cpython-34m.so"
WSGIPythonHome "/venv/path"
```

This is the value we will use in `/etc/httpd/conf.modules.d/10-wsgi.conf`.