### PR TITLE
Work around long-running "yum update" process

### DIFF
--- a/playbook/build_ami/main.yml
+++ b/playbook/build_ami/main.yml
@@ -88,6 +88,8 @@
       ignore_errors: yes
 
     - name: "disable boot-time yum update"
+      become: yes
+      become_user: "{{ remote_admin_account }}"
       lineinfile:
         dest: /etc/cloud/cloud.cfg
         state: absent

--- a/playbook/build_ami/main.yml
+++ b/playbook/build_ami/main.yml
@@ -79,6 +79,14 @@
     - "./../../vars/env/{{ env }}/env.yml"
     - "./../../vars/all_var.yml"
 
+  pre_tasks:
+    - name: "kill yum"
+      become: yes
+      become_user: "{{ remote_admin_account }}"
+      shell: |
+        kill "$(cat /var/run/yum.pid)"
+      ignore_errors: yes
+
   roles:
     - ../../roles/base_patch
     - ../../roles/snmp_update_public

--- a/playbook/build_ami/main.yml
+++ b/playbook/build_ami/main.yml
@@ -87,6 +87,12 @@
         kill "$(cat /var/run/yum.pid)"
       ignore_errors: yes
 
+    - name: "disable boot-time yum update"
+      lineinfile:
+        dest: /etc/cloud/cloud.cfg
+        state: absent
+        regexp: '^.*yum\s-y\supdate.*$'
+
   roles:
     - ../../roles/base_patch
     - ../../roles/snmp_update_public

--- a/roles/base_patch/tasks/main.yml
+++ b/roles/base_patch/tasks/main.yml
@@ -6,13 +6,6 @@
 - name: "fix sudoers file"
   import_tasks: ./fix_sudoers.yml
 
-- name: "clean up /root for dataservers"
-  become_user: "{{ remote_admin_account }}"
-  become: yes
-  file:
-    dest: "/root/fips_140_2_update.log.*"
-    state: absent
-
 - name: "apply security patches"
   become_user: "{{ remote_admin_account }}"
   become: yes


### PR DESCRIPTION
The base image we use for our builds tries to update _all_ packages on boot, which can take a very long time and is mostly unnecessary. This change tries to workaround this problem by cancelling the process so our builds can proceed in a reasonable amount of time. In lieu of updating all packages, our build process picks up essential security updates using `yum update-minimal --security`.