### PR TITLE
Remove deprecated '--allow-external' flag from pip install invocations

### DIFF
--- a/playbook/appherd/roles/app_tools/tasks/main.yml
+++ b/playbook/appherd/roles/app_tools/tasks/main.yml
@@ -18,7 +18,6 @@
     - python-psycopg2
     - httpd
     - httpd-devel
-    # - mod_wsgi
     - bzip2-devel
     - openssl-devel
     - ncurses-devel
@@ -34,7 +33,6 @@
     - libxslt-devel
     - libffi
     - libffi-devel
-    # - libpcap-devel
     - xz-devel
     - zlib-devel
 

--- a/playbook/appherd/roles/app_update/tasks/main.yml
+++ b/playbook/appherd/roles/app_update/tasks/main.yml
@@ -97,7 +97,7 @@
     {{ cf_app_py_virtual_env }}/bin/pip{{ python_ver }} {{ item }}
   with_items:
     - "install --upgrade pip {{ pip_extra_args }} "
-    - "install psycopg2 {{ pip_extra_args }} --allow-external psycopg2 "
+    - "install psycopg2 {{ pip_extra_args }}"
     - "install -r {{ cf_app_pyapp_home }}/{{ common_project_name }}/requirements/requirements.txt {{ pip_extra_args }} "
 
 - name: "install boto3 for collectstatic"

--- a/playbook/appserver/roles/app_update/tasks/main.yml
+++ b/playbook/appserver/roles/app_update/tasks/main.yml
@@ -158,7 +158,7 @@
     {{ cf_app_py_virtual_env }}/bin/pip{{ python_ver }} {{ item }}
   with_items:
     - "install --upgrade pip {{ pip_extra_args }} "
-    - "install psycopg2 {{ pip_extra_args }} --allow-external psycopg2 "
+    - "install psycopg2 {{ pip_extra_args }}"
     - "install -r {{ cf_app_pyapp_home }}/{{ common_project_name }}/requirements/requirements.txt {{ pip_extra_args }} "
 
 # Relative reference from playbook/appserver


### PR DESCRIPTION
This flag is causing builds to fail. See recent pip release notes: https://pip.pypa.io/en/stable/news/#b1-2018-03-31