### PR TITLE
BLUEBUTTON-207 Update logger env and logrotate fix

### DIFF
--- a/playbook/appherd/roles/log_rotate/tasks/main.yml
+++ b/playbook/appherd/roles/log_rotate/tasks/main.yml
@@ -14,7 +14,9 @@
       missingok
       notifempty
       compress
-      size 20k
+      size 10M
+      rotate 10
+      copytruncate
       daily
       create 0776 {{ cf_app_pyapps_user }} logreader
       }

--- a/vars/env/dev/env.yml
+++ b/vars/env/dev/env.yml
@@ -428,47 +428,51 @@ env_django_logging: |
       },
       'loggers': {
           'hhs_server': {
-              'handlers': ['console', 'file_debug'],
+              'handlers': ['file_debug'],
               'level': 'DEBUG',
           },
           'hhs_oauth_server.accounts': {
-              'handlers': ['console', 'file_debug'],
+              'handlers': ['file_debug'],
               'level': 'DEBUG',
           },
           'hhs_server_debug': {
-              'handlers': ['console', 'file_debug'],
+              'handlers': ['file_debug'],
               'level': 'DEBUG',
           },
           'hhs_server_error': {
-              'handlers': ['console', 'file_error', 'mail_admins'],
+              'handlers': ['file_error', 'mail_admins'],
               'level': 'ERROR',
           },
           'unsuccessful_logins': {
-              'handlers': ['console', 'badlogin_info'],
+              'handlers': ['badlogin_info'],
               'level': 'INFO',
           },
           'admin_interface': {
-              'handlers': ['console', 'adminuse_info'],
+              'handlers': ['adminuse_info'],
               'level': 'INFO',
           },
           'hhs_server_info': {
-              'handlers': ['console', 'file_info'],
+              'handlers': ['file_info'],
               'level': 'INFO',
           },
           'oauth2_provider': {
-              'handlers': ['console', 'file_info'],
+              'handlers': ['file_info'],
               'level': 'INFO',
           },
           'oauthlib': {
-              'handlers': ['console', 'file_info'],
+              'handlers': ['file_info'],
               'level': 'INFO',
           },
           'tests': {
-              'handlers': ['console', 'file_debug'],
+              'handlers': ['file_debug'],
               'level': 'DEBUG',
           },
+          'audit': {
+              'handlers': ['perf_mon'],
+              'level': 'INFO',
+          },
           'performance': {
-              'handlers': ['console', 'perf_mon'],
+              'handlers': ['perf_mon'],
               'level': 'INFO',
           }
       },

--- a/vars/env/impl/env.yml
+++ b/vars/env/impl/env.yml
@@ -428,51 +428,55 @@ env_django_logging: |
       },
       'loggers': {
           'hhs_server': {
-              'handlers': ['console', 'file_debug'],
+              'handlers': ['file_debug'],
               'level': 'DEBUG',
           },
           'hhs_oauth_server.accounts': {
-              'handlers': ['console', 'file_info'],
+              'handlers': ['file_info'],
               'level': 'INFO',
           },
           'hhs_server_debug': {
-              'handlers': ['console', 'file_debug'],
+              'handlers': ['file_debug'],
               'level': 'DEBUG',
           },
           'hhs_server_error': {
-              'handlers': ['console', 'file_error', 'mail_admins'],
+              'handlers': ['file_error', 'mail_admins'],
               'level': 'ERROR',
           },
           'unsuccessful_logins': {
-              'handlers': ['console', 'badlogin_info'],
+              'handlers': ['badlogin_info'],
               'level': 'INFO',
           },
           'admin_interface': {
-              'handlers': ['console', 'adminuse_info'],
+              'handlers': ['adminuse_info'],
               'level': 'INFO',
           },
           'hhs_server_info': {
-              'handlers': ['console', 'file_info'],
+              'handlers': ['file_info'],
               'level': 'INFO',
           },
           'oauth2_provider': {
-              'handlers': ['console', 'file_info'],
+              'handlers': ['file_info'],
               'level': 'INFO',
           },
           'unsuccessful_login': {
-              'handlers': ['console', 'file_info'],
+              'handlers': ['file_info'],
               'level': 'INFO',
           },
           'oauthlib': {
-              'handlers': ['console', 'file_info'],
+              'handlers': ['file_info'],
               'level': 'INFO',
           },
           'tests': {
               'handlers': ['console'],
               'level': 'DEBUG',
           },
+          'audit': {
+              'handlers': ['perf_mon'],
+              'level': 'INFO',
+          },
           'performance': {
-              'handlers': ['console', 'perf_mon'],
+              'handlers': ['perf_mon'],
               'level': 'INFO',
           }
       },

--- a/vars/env/prod/env.yml
+++ b/vars/env/prod/env.yml
@@ -428,39 +428,39 @@ env_django_logging: |
       },
       'loggers': {
           'hhs_server': {
-              'handlers': ['console', 'file_debug'],
+              'handlers': ['file_debug'],
               'level': 'DEBUG',
           },
           'hhs_oauth_server.accounts': {
-              'handlers': ['console', 'file_info'],
+              'handlers': ['file_info'],
               'level': 'INFO',
           },
           'hhs_server_debug': {
-              'handlers': ['console', 'file_debug'],
+              'handlers': ['file_debug'],
               'level': 'DEBUG',
           },
           'hhs_server_error': {
-              'handlers': ['console', 'file_error', 'mail_admins'],
+              'handlers': ['file_error', 'mail_admins'],
               'level': 'ERROR',
           },
           'unsuccessful_logins': {
-              'handlers': ['console', 'badlogin_info'],
+              'handlers': ['badlogin_info'],
               'level': 'INFO',
           },
           'admin_interface': {
-              'handlers': ['console', 'adminuse_info'],
+              'handlers': ['adminuse_info'],
               'level': 'INFO',
           },
           'hhs_server_info': {
-              'handlers': ['console', 'file_info'],
+              'handlers': ['file_info'],
               'level': 'INFO',
           },
           'oauth2_provider': {
-              'handlers': ['console', 'file_info'],
+              'handlers': ['file_info'],
               'level': 'INFO',
           },
           'unsuccessful_login': {
-              'handlers': ['console', 'file_info'],
+              'handlers': ['file_info'],
               'level': 'INFO',
           },
           'oauthlib': {
@@ -471,8 +471,12 @@ env_django_logging: |
               'handlers': ['console'],
               'level': 'DEBUG',
           },
+          'audit': {
+              'handlers': ['perf_mon'],
+              'level': 'INFO',
+          },
           'performance': {
-              'handlers': ['console', 'perf_mon'],
+              'handlers': ['perf_mon'],
               'level': 'INFO',
           }
       },

--- a/vars/env/test/env.yml
+++ b/vars/env/test/env.yml
@@ -426,31 +426,31 @@ env_django_logging: |
       },
       'loggers': {
           'hhs_server': {
-              'handlers': ['console', 'file_debug'],
+              'handlers': ['file_debug'],
               'level': 'DEBUG',
           },
           'hhs_oauth_server.accounts': {
-              'handlers': ['console', 'file_info'],
+              'handlers': ['file_info'],
               'level': 'DEBUG',
           },
           'hhs_server_debug': {
-              'handlers': ['console', 'file_debug'],
+              'handlers': ['file_debug'],
               'level': 'DEBUG',
           },
           'hhs_server_error': {
-              'handlers': ['console', 'file_error', 'mail_admins'],
+              'handlers': ['file_error', 'mail_admins'],
               'level': 'ERROR',
           },
           'unsuccessful_logins': {
-              'handlers': ['console', 'badlogin_info'],
+              'handlers': ['badlogin_info'],
               'level': 'INFO',
           },
           'admin_interface': {
-              'handlers': ['console', 'adminuse_info'],
+              'handlers': ['adminuse_info'],
               'level': 'INFO',
           },
           'hhs_server_info': {
-              'handlers': ['console', 'file_info'],
+              'handlers': ['file_info'],
               'level': 'INFO',
           },
           'oauth2_provider': {
@@ -465,8 +465,12 @@ env_django_logging: |
               'handlers': ['console'],
               'level': 'DEBUG',
           },
+          'audit': {
+              'handlers': ['perf_mon'],
+              'level': 'INFO',
+          },
           'performance': {
-              'handlers': ['console', 'perf_mon'],
+              'handlers': ['perf_mon'],
               'level': 'INFO',
           }
       },


### PR DESCRIPTION
* Add an additional logger called 'audit' to the env.yml files for dev, test, impl, prod.
* Fix the log rotate setup so that uwsgi processes don't lose their file handles when logs are rotated/gzipp'ed using the "copytruncate" option.
* Change log rotate options to keep a 10 file history and rotate when over 10MB in size.