### PR TITLE
BLUEBUTTON-207 Remove double quotes from jsonout log formatter for message

### DIFF
--- a/vars/env/dev/env.yml
+++ b/vars/env/dev/env.yml
@@ -364,7 +364,7 @@ env_django_logging: |
           },
           'jsonout': {
               'format': '{"time": "%(asctime)s", "level": "%(levelname)s", '
-                        '"name": "%(name)s", "message": "%(message)s"}',
+                        '"name": "%(name)s", "message": %(message)s}',
               'datefmt': '%Y-%m-%d %H:%M:%S'
 
           }

--- a/vars/env/impl/env.yml
+++ b/vars/env/impl/env.yml
@@ -365,7 +365,7 @@ env_django_logging: |
           },
           'jsonout': {
               'format': '{"time": "%(asctime)s", "level": "%(levelname)s", '
-                        '"name": "%(name)s", "message": "%(message)s"}',
+                        '"name": "%(name)s", "message": %(message)s}',
               'datefmt': '%Y-%m-%d %H:%M:%S'
 
           }

--- a/vars/env/prod/env.yml
+++ b/vars/env/prod/env.yml
@@ -363,7 +363,7 @@ env_django_logging: |
           },
           'jsonout': {
               'format': '{"time": "%(asctime)s", "level": "%(levelname)s", '
-                        '"name": "%(name)s", "message": "%(message)s"}',
+                        '"name": "%(name)s", "message": %(message)s}',
               'datefmt': '%Y-%m-%d %H:%M:%S'
 
           }

--- a/vars/env/test/env.yml
+++ b/vars/env/test/env.yml
@@ -361,7 +361,7 @@ env_django_logging: |
           },
           'jsonout': {
               'format': '{"time": "%(asctime)s", "level": "%(levelname)s", '
-                        '"name": "%(name)s", "message": "%(message)s"}',
+                        '"name": "%(name)s", "message": %(message)s}',
               'datefmt': '%Y-%m-%d %H:%M:%S'
 
           }


### PR DESCRIPTION
The message passed to the jsonout log formatter is now in JSON, so the double quotes need to be removed.
