### PR TITLE
[BLUEBUTTON-127] Enable gzip compression

### DIFF
--- a/roles/nginx/files/nginx.conf
+++ b/roles/nginx/files/nginx.conf
@@ -8,6 +8,11 @@ events {
 }
 
 http {
+  gzip on;
+  gzip_types text/html text/plain application/json application/json+fhir;
+  gzip_min_length 1000;
+  gzip_proxied no-cache no-store private expired auth;
+
   sendfile             on;
   keepalive_timeout    0;
   log_format main '$http_x_forwarded_for - $remote_user [$time_local] '


### PR DESCRIPTION
This enables gzip compression for a few content types: 

- `text/html`
- `text/plain`
- `application/json`
- `application/json+fhir`

In order to see the benefit of gzip compression, the client must send the `Accept-Encoding: gzip` header as part of their request. Otherwise, the server will respond with the unmodified content type and encoding.

What this means: this is an opt-in enhancement and will not create any backward compatibility issues that would otherwise require communication to developers pre-deployment. Still, we should document that it is available and encourage developers to start using it at their convenience.