### PR TITLE
BLUEBUTTON-207 Update IMPL to use jsonout log formatter

### DIFF
--- a/vars/env/impl/env.yml
+++ b/vars/env/impl/env.yml
@@ -422,7 +422,7 @@ env_django_logging: |
           'perf_mon': {
               'level': 'INFO',
               'class': 'logging.FileHandler',
-              'formatter': 'verbose',
+              'formatter': 'jsonout',
               'filename': '/var/log/pyapps/perf_mon.log',
           }
       },


### PR DESCRIPTION
The logging was pointing to verbose formatter instead of jsonout for IMPL.