### PR TITLE
Allow http callbacks in lower envs

### DIFF
--- a/roles/nginx/files/uwsgi.ini
+++ b/roles/nginx/files/uwsgi.ini
@@ -14,3 +14,6 @@ processes = 8
 threads = 2
 harakiri = 300
 socket-timeout = 300
+{% if allow_insecure_callback %}
+env = OAUTHLIB_INSECURE_TRANSPORT={{ allow_insecure_callback }}
+{% endif %}

--- a/vars/env/dev/env.yml
+++ b/vars/env/dev/env.yml
@@ -473,3 +473,5 @@ env_django_logging: |
           }
       },
   }
+
+allow_insecure_callback: true

--- a/vars/env/impl/env.yml
+++ b/vars/env/impl/env.yml
@@ -477,3 +477,5 @@ env_django_logging: |
           }
       },
   }
+
+allow_insecure_callback: true

--- a/vars/env/test/env.yml
+++ b/vars/env/test/env.yml
@@ -471,3 +471,5 @@ env_django_logging: |
           }
       },
   }
+
+allow_insecure_callback: true


### PR DESCRIPTION
- Updated oauth lib requires an environment var to be set to allow http
callbacks

- This sets that env var to true for low envs