### PR TITLE
Bluebutton 289 Fix remaining issues

### DIFF
--- a/locust/run.sh
+++ b/locust/run.sh
@@ -34,7 +34,7 @@ docker build -f ./Dockerfiles/Dockerfile.tkns -t bb_tkns .
 docker build -f ./Dockerfiles/Dockerfile.locust -t bb_locust .
 
 echo "Get access tokens..."
-docker run --rm -it bb_tkns \
+docker run --rm -t bb_tkns \
   -w ${BB_TKNS_WORKERS:-2} \
   -id $BB_CLIENT_ID \
   -secret $BB_CLIENT_SECRET \
@@ -56,7 +56,7 @@ docker run \
   -e BB_LOAD_TEST_MAX_WAIT=${BB_LOAD_TEST_MAX_WAIT:-5000} \
   -e BB_CLIENT_ID=${BB_CLIENT_ID} \
   -e BB_CLIENT_SECRET=${BB_CLIENT_SECRET} \
-  --rm -it bb_locust \
+  --rm -t bb_locust \
   --host https://${BB_SUB_DOMAIN} \
   --no-web \
   --only-summary \

--- a/playbook/loadtest/main.yml
+++ b/playbook/loadtest/main.yml
@@ -15,7 +15,7 @@
   vars:
     ansible_ssh_pipelining: no
     results_fn: "{{ lookup('pipe', 'date +%Y%m%d%H%M') }}_loadtest_results.log"
-    src_results_file: "/home/ec2-user/bluebutton-web-deployment/locust/{{ results_fn }}"
+    src_results_file: "/home/ec2-user/bluebutton-web-deployment/locust/results.log"
     dst_results_file: "{{ env }}/{{ results_fn }}"
     aws_access_key: "{{ hostvars['localhost'] }}"
 
@@ -99,9 +99,8 @@
         env | grep BB_
         echo
         echo
-        fn="{{ results_fn }}"
         date
-        ./run.sh ${BB_LOAD_TEST_TYPE} >${fn} 2>&1 
+        ./run.sh ${BB_LOAD_TEST_TYPE} >results.log 2>&1 
         date
         exit 0
       register: command_result


### PR DESCRIPTION
* Remove the -i (interactive) option from the docker-run commands in the loadtest run.sh script. Was receiving an error when running under the Ansible shell module vs. running manually on the instance.
* Fix issue with results.log file timestamp.