### PR TITLE
BLUEBUTTON-354 change from Chrony to NTPD time sync

### DIFF
--- a/roles/base_patch/tasks/main.yml
+++ b/roles/base_patch/tasks/main.yml
@@ -48,15 +48,15 @@
   become: yes
   shell: yum update-minimal --security -y
 
-- name: "add amazon ntp server to chrony.conf"
+- name: "add amazon ntp server to ntp.conf"
   lineinfile:
-    path: /etc/chrony.conf
+    path: /etc/ntp.conf
     insertafter: EOF
     line: 'server 169.254.169.123 prefer iburst'
   become: yes
 
-- name: "restart chronyd"
+- name: "restart ntpd"
   service:
-    name: chronyd
+    name: ntpd
     state: restarted
   become: yes


### PR DESCRIPTION
The current deployment fails when trying to reference the file /etc/chrony.conf . Crony is no longer installed/used.

NTPD is being used for time sync in the new golden image instead. I changed the configuration to add the AWS time server to the ntp.conf instead.

Please reference the Jira ticket for more info on testing and other related gold image tickets.  https://jira.cms.gov/browse/BLUEBUTTON-354


