### PR TITLE
Resolve deployment issue due to package name change

### DIFF
--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -31,7 +31,7 @@
     state: present
   with_items:
     - uwsgi
-    - uwsgi-plugin-python3
+    - uwsgi-plugin-python34
 
 - name: "create sock file"
   become_user: "{{ remote_admin_account }}"


### PR DESCRIPTION
Changed the nginx role task to install the package ""uwsgi-plugin-python34" instead of "uwsgi-plugin-python3". The YUM install started getting a "package not found" type of error on recent builds.