### PR TITLE
Setting DJANGO_DOTENV_FILE location

### DIFF
--- a/playbook/appherd/roles/django_prep/tasks/main.yml
+++ b/playbook/appherd/roles/django_prep/tasks/main.yml
@@ -11,6 +11,8 @@
   become: yes
   # We only want to run migration on one server in the fleet
   run_once: yes
+  environment:
+    DJANGO_DOTENV_FILE: "{{ install_root }}"
   django_manage:
     command: migrate
     app_path: "{{ install_root }}/{{ project_name }}/"


### PR DESCRIPTION
Setting DJANGO_DOTENV_FILE location to pickup the .env file during django migrate. 