### PR TITLE
Updating boto3 to pair with Django 2.x in handling static files.

### DIFF
--- a/roles/app_install/tasks/main.yml
+++ b/roles/app_install/tasks/main.yml
@@ -67,7 +67,7 @@
   become: yes
   pip:
     name: boto3
-    version: 1.4.0
+    version: 1.9.43
     state: present
     extra_args: " --upgrade {{ pip_extra_args }} "
     virtualenv: "{{ venv }}"


### PR DESCRIPTION
Updating Boto3 to latest stable, django 2.x requires >= 1.4.4. We have been using 1.4.0. I've installed 1.9.43 on a test DEV EC2 instance and all appears good. 