### PR TITLE
Typo setting nginx cert vars. used vault_env_* and should be env_*

### DIFF
--- a/vars/all_var.yml
+++ b/vars/all_var.yml
@@ -272,9 +272,9 @@
 
   # Nginx cert, key and fullchain files
   # Assigned Certificates and Keys to be copied to /etc/ssl/certs
-  env_www_cert_file: "{{ vault_env_www_cert_file }}"
-  env_www_key_file: "{{ vault_env_www_key_file }}"
-  env_www_fullchain_file: "{{ vault_env_www_fullchain_file }}"
+  env_www_cert_file: "{{ env_www_cert_file }}"
+  env_www_key_file: "{{ env_www_key_file }}"
+  env_www_fullchain_file: "{{ env_www_fullchain_file }}"
 
   # AppServer cert and key for communication with FHIR Server
   app_fhir_cert: "{{ env_app_fhir_cert }}"


### PR DESCRIPTION
Typo setting nginx cert vars. used vault_env_* and should be env_*

All other var files use the vault, this one does not. 