### PR TITLE
588 s3 static

### DIFF
--- a/roles/env_vars/templates/env.j2
+++ b/roles/env_vars/templates/env.j2
@@ -21,7 +21,7 @@ AWS_S3_CUSTOM_DOMAIN="s3.amazonaws.com/{{ s3_storage_bucket_name }}"
 # TODO(rnagle): do we need these for static files?
 AWS_ACCESS_KEY_ID="{{ aws_access_id }}"
 AWS_SECRET_ACCESS_KEY="{{ aws_secret_key }}"
-AWS_STORAGE_BUCKET_NAME={{ s3_storage_bucket_name }}
+AWS_STORAGE_BUCKET_NAME="{{ s3_storage_bucket_name }}"
 
 # FHIR/Backend Server config
 DJANGO_FHIR_SERVER_DEFAULT="{{ django_fhirserver_id }}"

--- a/roles/env_vars/templates/env.j2
+++ b/roles/env_vars/templates/env.j2
@@ -21,6 +21,7 @@ AWS_S3_CUSTOM_DOMAIN="s3.amazonaws.com/{{ s3_storage_bucket_name }}"
 # TODO(rnagle): do we need these for static files?
 AWS_ACCESS_KEY_ID="{{ aws_access_id }}"
 AWS_SECRET_ACCESS_KEY="{{ aws_secret_key }}"
+AWS_STORAGE_BUCKET_NAME={{ s3_storage_bucket_name }}
 
 # FHIR/Backend Server config
 DJANGO_FHIR_SERVER_DEFAULT="{{ django_fhirserver_id }}"


### PR DESCRIPTION
When running collectstatic the process fails because botocore expects the variable AWS_STORAGE_BUCKET_NAME to be present. Currently, it complains as follows:

File "/var/virtualenv/hhs_o_server/lib64/python3.6/site-packages/botocore/handlers.py", line 218, in validate_bucket_name
    if VALID_BUCKET.search(bucket) is None:
TypeError: expected string or bytes-like object

To speed up testing, I added this variable to the dev environment directly and collectstatic works. Not sure how this broke. *shrug*