### PR TITLE
Adding .env location to collectstatic ansible step.

### DIFF
--- a/playbook/appherd/roles/django_prep/tasks/main.yml
+++ b/playbook/appherd/roles/django_prep/tasks/main.yml
@@ -17,10 +17,7 @@
     command: migrate
     app_path: "{{ install_root }}/{{ project_name }}/"
     virtualenv: "{{ venv }}"
-  register: output
   when: ( migrate is defined ) and ( migrate == 'yes' )
-
-- debug: var=output.stdout_lines
 
 - name: "Add Group roles to database"
   become_user: "{{ remote_admin_account }}"
@@ -64,6 +61,8 @@
   become_user: "{{ remote_admin_account }}"
   become: yes
   run_once: yes
+  environment:
+    DJANGO_DOTENV_FILE: "{{ install_root }}"
   django_manage:
     command: collectstatic
     app_path: "{{ install_root }}/{{ project_name }}/"


### PR DESCRIPTION
It would appear the location of the .env file had previously moved from {{ install_root }}/{{ project_name }} and is now just at {{ install_root }} and no longer in the same directory as manage.py. We saw this issue come up with the migration step of Django setup and now it was affecting the collectstatic. I've added code to notify the collectstatic of where to load the .env. 

I also cleaned up some debug information which was not working. I was unable to capture output of the django_manage module and it appears this method might only work for shell commands. 