### PR TITLE
626: Rename ASG's, clean-up pipeline. 

### DIFF
--- a/Jenkinsfiles/Jenkinsfile.deploy_ami
+++ b/Jenkinsfiles/Jenkinsfile.deploy_ami
@@ -124,7 +124,7 @@ pipeline {
       }
     }
 
-    stage('Checkout Repos') {
+    stage('Checkout Repo') {
       parallel {
         stage('Checkout Deployment Repo') {
           steps {
@@ -166,47 +166,45 @@ pipeline {
     }
 
     stage('Install requirements') {
-      parallel {
-        stage('Upgrade PIP and CFFI') {
-          steps {
-            dir('code') {
-              script {
-                sh """
-                  virtualenv -ppython2.7 venv1
-                  . venv1/bin/activate
+      steps {
+        dir('code') {
+          script {
+            sh """
+              virtualenv -ppython2.7 venv
+              . venv/bin/activate
 
-                  pip install --upgrade pip
-                  pip install --upgrade cffi
-                """
-              }
-            }
+              pip install --upgrade pip
+              pip install --upgrade cffi
+            """
           }
         }
-        stage('Install Ansible and Boto') {
-          steps {
-            dir('code') {
-              script {
-                sh """
-                  virtualenv -ppython2.7 venv2
-                  . venv2/bin/activate
+      }
+    }
 
-                  pip install ansible==2.4.2.0
-                  pip install boto
-                """
-              }
-            }
+    stage('Install Ansible and Boto') {
+      steps {
+        dir('code') {
+          script {
+            sh """
+              virtualenv -ppython2.7 venv
+              . venv/bin/activate
+
+              pip install ansible==2.4.2.0
+              pip install boto
+            """
           }
         }
-        stage('Install Terraform Version') {
-          steps {
-            dir('tfenv') {
-              script {
-                sh """
-                  bin/tfenv install
-                  terraform --version
-                """
-              }
-            }
+      }
+    }
+
+    stage('Install Terraform Version') {
+      steps {
+        dir('tfenv') {
+          script {
+            sh """
+              bin/tfenv install
+              terraform --version
+            """
           }
         }
       }
@@ -309,7 +307,7 @@ pipeline {
                 file(credentialsId: vault_pass, variable: 'vp')
               ]) {
                 sh """
-                  . venv1/bin/activate
+                  . venv2/bin/activate
 
                   rm -Rf ./tmp
 

--- a/Jenkinsfiles/Jenkinsfile.deploy_ami
+++ b/Jenkinsfiles/Jenkinsfile.deploy_ami
@@ -307,7 +307,7 @@ pipeline {
                 file(credentialsId: vault_pass, variable: 'vp')
               ]) {
                 sh """
-                  . venv2/bin/activate
+                  . venv/bin/activate
 
                   rm -Rf ./tmp
 

--- a/roles/base_patch/tasks/main.yml
+++ b/roles/base_patch/tasks/main.yml
@@ -25,12 +25,12 @@
   args:
     executable: /bin/bash
 
-- name: "kill yum"
+/*- name: "kill yum"
   become: yes
   become_user: "{{ remote_admin_account }}"
   shell: |
     kill "$(cat /var/run/yum.pid)"
-  ignore_errors: yes
+  ignore_errors: yes */
 
 - name: "disable boot-time yum update"
   become: yes

--- a/roles/base_patch/tasks/main.yml
+++ b/roles/base_patch/tasks/main.yml
@@ -25,13 +25,6 @@
   args:
     executable: /bin/bash
 
-#- name: "kill yum"
-#  become: yes
-#  become_user: "{{ remote_admin_account }}"
-#  shell: |
-#    kill "$(cat /var/run/yum.pid)"
-#  ignore_errors: yes
-
 - name: "disable boot-time yum update"
   become: yes
   become_user: "{{ remote_admin_account }}"

--- a/roles/base_patch/tasks/main.yml
+++ b/roles/base_patch/tasks/main.yml
@@ -25,12 +25,12 @@
   args:
     executable: /bin/bash
 
-/*- name: "kill yum"
-  become: yes
-  become_user: "{{ remote_admin_account }}"
-  shell: |
-    kill "$(cat /var/run/yum.pid)"
-  ignore_errors: yes */
+#- name: "kill yum"
+#  become: yes
+#  become_user: "{{ remote_admin_account }}"
+#  shell: |
+#    kill "$(cat /var/run/yum.pid)"
+#  ignore_errors: yes
 
 - name: "disable boot-time yum update"
   become: yes

--- a/terraform/modules/asg/main.tf
+++ b/terraform/modules/asg/main.tf
@@ -88,7 +88,7 @@ resource "aws_launch_configuration" "app" {
 ##
 resource "aws_autoscaling_group" "main" {
   availability_zones        = ["${var.azs}"]
-  name                      = "bb-${var.stack}-app-${aws_launch_configuration.app.name}"
+  name                      = "asg-${aws_launch_configuration.app.name}"
   desired_capacity          = "${var.asg_desired}"
   max_size                  = "${var.asg_max}"
   min_size                  = "${var.asg_min}"


### PR DESCRIPTION
General Cleanup

- Removed parallel execution of install requirements, required independent venv, which tripped up later steps. 
- Removed unnecessary 'kill yum' step in the 'base_patch' role. 
- Renaming ASG's. 
- Chose not to move the location of hhs_oauth_server app, after researching Django project and file structures, it feels fine to me. ref: https://django-project-skeleton.readthedocs.io/en/latest/structure.html

