### PR TITLE
BLUEBUTTON-192 Install RedHat packages needed for Pillow install

### DIFF
--- a/roles/app_tools/tasks/main.yml
+++ b/roles/app_tools/tasks/main.yml
@@ -11,6 +11,8 @@
     - git
     - postgresql-devel
     - python-devel
+    - zlib-devel
+    - libjpeg-turbo-devel
 
 - name: "install pip 9.0.3"
   become_user: "{{ remote_admin_account }}"


### PR DESCRIPTION
This adds the RedHat packages to support the python Pillow package installation:
* zlib-devel
* libjpeg-turbo-devel

NOTE: There may be additional packages needed, but found several references to just needing those two only.