### PR TITLE
BLUEBUTTON-522 Applications List

### DIFF
--- a/roles/env_vars/templates/env.j2
+++ b/roles/env_vars/templates/env.j2
@@ -66,6 +66,6 @@ DJANGO_APP_LOGO_SIZE_MAX="{{ django_app_logo_size_max }}"
 DJANGO_APP_LOGO_WIDTH_MAX="{{ django_app_logo_width_max }}"
 DJANGO_APP_LOGO_HEIGHT_MAX="{{ django_app_logo_height_max }}"
 
-# Application category slugs to exclude from externally
+# Application label slugs to exclude from externally
 # published lists, like those used for internal use testing.
 DJANGO_APP_LIST_EXCLUDE="{{ django_app_list_exclude }}"

--- a/roles/env_vars/templates/env.j2
+++ b/roles/env_vars/templates/env.j2
@@ -66,3 +66,6 @@ DJANGO_APP_LOGO_SIZE_MAX="{{ django_app_logo_size_max }}"
 DJANGO_APP_LOGO_WIDTH_MAX="{{ django_app_logo_width_max }}"
 DJANGO_APP_LOGO_HEIGHT_MAX="{{ django_app_logo_height_max }}"
 
+# Application category slugs to exclude from externally
+# published lists, like those used for internal use testing.
+DJANGO_APP_LIST_EXCLUDE="{{ django_app_list_exclude }}"

--- a/roles/nginx/files/nginx.conf
+++ b/roles/nginx/files/nginx.conf
@@ -55,7 +55,7 @@ http {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
 
-    location ~ /(health|{{ django_admin_redirector }}admin/) {
+    location ~ /(health|{{ django_admin_redirector }}admin/|\.well-known/applications) {
       real_ip_header   X-Forwarded-For;
       set_real_ip_from 10.0.0.0/8;
 

--- a/vars/all_var.yml
+++ b/vars/all_var.yml
@@ -217,7 +217,7 @@
   django_app_logo_width_max: "{{ env_django_app_logo_width_max }}"
   django_app_logo_height_max: "{{ env_django_app_logo_height_max }}"
 
-  # Application category slugs to exclude from externally
+  # Application label slugs to exclude from externally
   # published lists, like those used for internal use testing.
   django_app_list_exclude: "{{ env_django_app_list_exclude }}"
 

--- a/vars/all_var.yml
+++ b/vars/all_var.yml
@@ -217,6 +217,10 @@
   django_app_logo_width_max: "{{ env_django_app_logo_width_max }}"
   django_app_logo_height_max: "{{ env_django_app_logo_height_max }}"
 
+  # Application category slugs to exclude from externally
+  # published lists, like those used for internal use testing.
+  django_app_list_exclude: "{{ env_django_app_list_exclude }}"
+
   # Add a variable endpoint for admin/
   # eg. To move from /admin/ to /secret/admin/
   #     set redirector to 'secret/'

--- a/vars/env/dev/env.yml
+++ b/vars/env/dev/env.yml
@@ -156,7 +156,7 @@ env_django_app_logo_height_max: "128"
 
 # Application category slugs to exclude from externally
 # published lists, like those used for internal use testing.
-env_django_app_list_exclude: "['internal-use', 'do-not-publish']"
+env_django_app_list_exclude: "['internal-use']"
 
 # add new url prefix for admin/
 env_django_admin_redirector: "{{ vault_env_django_admin_redirector }}"

--- a/vars/env/dev/env.yml
+++ b/vars/env/dev/env.yml
@@ -154,7 +154,7 @@ env_django_app_logo_size_max: "100"
 env_django_app_logo_width_max: "128"
 env_django_app_logo_height_max: "128"
 
-# Application category slugs to exclude from externally
+# Application label slugs to exclude from externally
 # published lists, like those used for internal use testing.
 env_django_app_list_exclude: "['internal-use']"
 

--- a/vars/env/dev/env.yml
+++ b/vars/env/dev/env.yml
@@ -154,6 +154,10 @@ env_django_app_logo_size_max: "100"
 env_django_app_logo_width_max: "128"
 env_django_app_logo_height_max: "128"
 
+# Application category slugs to exclude from externally
+# published lists, like those used for internal use testing.
+env_django_app_list_exclude: "['internal-use', 'do-not-publish']"
+
 # add new url prefix for admin/
 env_django_admin_redirector: "{{ vault_env_django_admin_redirector }}"
 

--- a/vars/env/impl/env.yml
+++ b/vars/env/impl/env.yml
@@ -158,7 +158,7 @@ env_django_app_logo_size_max: "100"
 env_django_app_logo_width_max: "128"
 env_django_app_logo_height_max: "128"
 
-# Application category slugs to exclude from externally
+# Application label slugs to exclude from externally
 # published lists, like those used for internal use testing.
 env_django_app_list_exclude: "['internal-use']"
 

--- a/vars/env/impl/env.yml
+++ b/vars/env/impl/env.yml
@@ -158,6 +158,10 @@ env_django_app_logo_size_max: "100"
 env_django_app_logo_width_max: "128"
 env_django_app_logo_height_max: "128"
 
+# Application category slugs to exclude from externally
+# published lists, like those used for internal use testing.
+env_django_app_list_exclude: "['internal-use', 'do-not-publish']"
+
 # add new url prefix for admin/
 env_django_admin_redirector: "{{ vault_env_django_admin_redirector }}"
 

--- a/vars/env/impl/env.yml
+++ b/vars/env/impl/env.yml
@@ -160,7 +160,7 @@ env_django_app_logo_height_max: "128"
 
 # Application category slugs to exclude from externally
 # published lists, like those used for internal use testing.
-env_django_app_list_exclude: "['internal-use', 'do-not-publish']"
+env_django_app_list_exclude: "['internal-use']"
 
 # add new url prefix for admin/
 env_django_admin_redirector: "{{ vault_env_django_admin_redirector }}"

--- a/vars/env/prod/env.yml
+++ b/vars/env/prod/env.yml
@@ -156,7 +156,7 @@ env_django_app_logo_height_max: "128"
 
 # Application category slugs to exclude from externally
 # published lists, like those used for internal use testing.
-env_django_app_list_exclude: "['internal-use', 'do-not-publish']"
+env_django_app_list_exclude: "['internal-use']"
 
 # add new url prefix for admin/
 env_django_admin_redirector: "{{ vault_env_django_admin_redirector }}"

--- a/vars/env/prod/env.yml
+++ b/vars/env/prod/env.yml
@@ -154,7 +154,7 @@ env_django_app_logo_size_max: "100"
 env_django_app_logo_width_max: "128"
 env_django_app_logo_height_max: "128"
 
-# Application category slugs to exclude from externally
+# Application label slugs to exclude from externally
 # published lists, like those used for internal use testing.
 env_django_app_list_exclude: "['internal-use']"
 

--- a/vars/env/prod/env.yml
+++ b/vars/env/prod/env.yml
@@ -154,6 +154,10 @@ env_django_app_logo_size_max: "100"
 env_django_app_logo_width_max: "128"
 env_django_app_logo_height_max: "128"
 
+# Application category slugs to exclude from externally
+# published lists, like those used for internal use testing.
+env_django_app_list_exclude: "['internal-use', 'do-not-publish']"
+
 # add new url prefix for admin/
 env_django_admin_redirector: "{{ vault_env_django_admin_redirector }}"
 

--- a/vars/env/test/env.yml
+++ b/vars/env/test/env.yml
@@ -164,7 +164,7 @@ env_django_app_logo_height_max: "128"
 
 # Application category slugs to exclude from externally
 # published lists, like those used for internal use testing.
-env_django_app_list_exclude: "['internal-use', 'do-not-publish']"
+env_django_app_list_exclude: "['internal-use']"
 
 # add new url prefix for admin/
 env_django_admin_redirector: "{{ vault_env_django_admin_redirector }}"

--- a/vars/env/test/env.yml
+++ b/vars/env/test/env.yml
@@ -162,6 +162,10 @@ env_django_app_logo_size_max: "100"
 env_django_app_logo_width_max: "128"
 env_django_app_logo_height_max: "128"
 
+# Application category slugs to exclude from externally
+# published lists, like those used for internal use testing.
+env_django_app_list_exclude: "['internal-use', 'do-not-publish']"
+
 # add new url prefix for admin/
 env_django_admin_redirector: "{{ vault_env_django_admin_redirector }}"
 

--- a/vars/env/test/env.yml
+++ b/vars/env/test/env.yml
@@ -162,7 +162,7 @@ env_django_app_logo_size_max: "100"
 env_django_app_logo_width_max: "128"
 env_django_app_logo_height_max: "128"
 
-# Application category slugs to exclude from externally
+# Application label slugs to exclude from externally
 # published lists, like those used for internal use testing.
 env_django_app_list_exclude: "['internal-use']"
 


### PR DESCRIPTION
SUMMARY:
* Configure the nginx.conf so that the /.well-known/applications endpoint to be accessible by allowed_ips (including VPN) only!
* Added Django setting for DJANGO_APP_LIST_EXCLUDE used to exclude label slugs contained in this list from external applications listings.