### PR TITLE
BLUEBUTTON-312: Build Nightly Platinum AMI (Agnostic)

### DIFF
--- a/Jenkinsfiles/Jenkinsfile.build_app_ami
+++ b/Jenkinsfiles/Jenkinsfile.build_app_ami
@@ -1,26 +1,26 @@
 def private_key = ''
+def BB20_PLATINUM_AMI_ID = ''
+def release_version = ''
 def vault_pass = 'vault-pass'
 def aws_creds = 'cbj-deploy'
-def release_version = ''
 def slack_channel = '#bluebutton-alerts'
-def BB20_PLATINUM_AMI_ID = ''
 
 pipeline {
   agent {
     node {
       label ''
-      customWorkspace 'blue-button-build-ami'
+      customWorkspace 'blue-button-build-app-ami'
     }
   }
 
   parameters {
     string(
-      defaultValue: "",
+      defaultValue: "master",
       description: 'The branch of the application repo to build. Required.',
       name: 'BB20_APP_VERSION'
     )
     string(
-      defaultValue: "*/master",
+      defaultValue: "master",
       description: 'The branch of the deployment repo to use for the build.',
       name: 'BB20_DEPLOY_BRANCH'
     )
@@ -30,7 +30,7 @@ pipeline {
       name: 'BB20_PLATINUM_AMI_ID'
     )
     string(
-      defaultValue: "",
+      defaultValue: "subnet-81ecfbab",
       description: 'The subnet ID where the build server will be launched.',
       name: 'SUBNET_ID'
     )
@@ -47,10 +47,10 @@ pipeline {
   }
 
   stages {
-    stage('Ensure BB20_APP_VERSION, ENV, BB20_PLATINUM_AMI_ID and SUBNET_ID') {
+    stage('Ensure BB20_APP_VERSION, ENV and SUBNET_ID') {
       steps {
         sh """
-        if [ -z "${params.BB20_APP_VERSION}" ] || [ -z "${params.ENV}" ] || [ -z "${params.BB20_PLATINUM_AMI_ID}" ] || [ -z "${params.SUBNET_ID}" ]
+        if [ -z "${params.BB20_APP_VERSION}" ] || [ -z "${params.ENV}" ] || [ -z "${params.SUBNET_ID}" ]
         then
           exit 1
         fi
@@ -75,7 +75,7 @@ pipeline {
     stage('Set release_version var') {
       steps {
         script {
-          if params.BB20_APP_VERSION == 'master') {
+          if (params.BB20_APP_VERSION == 'master') {
             release_version = "latest-${params.BB20_APP_VERSION}"
           } else {
             // Git tag, commit hash or branch other than master
@@ -122,16 +122,14 @@ pipeline {
             if (params.BB20_PLATINUM_AMI_ID.startsWith("ami")) {
             BB20_PLATINUM_AMI = params.BB20_PLATINUM_AMI_ID
             } else {
-                withAWS(credentials: aws_creds, region: 'us-east-1') {
-                    BB20_PLATINUM_AMI = sh(
-                        script: "aws --region us-east-1 ec2 describe-images --filters Name=name,Values='bb20-platinum-??????????????' --query 'sort_by(Images,&CreationDate)[-1]' --output json | jq -r .ImageId",
-                        returnStdout: true
-                    ).trim()
+                withAwsCli(credentialsId: aws_creds, region: 'us-east-1') {
+                  BB20_PLATINUM_AMI = sh(
+                          script: "aws --region us-east-1 ec2 describe-images --filters Name=name,Values='bb20-platinum-??????????????' --query 'sort_by(Images,&CreationDate)[-1]' --output json | jq -r .ImageId",
+                          returnStdout: true
+                          ).trim()
+                    println("BB20 PLATINUM AMI ID: = ${BB20_PLATINUM_AMI}")
                   }
               }
-            sh """
-              echo "BB20 PLATINUM AMI ID: ${BB20_PLATINUM_AMI}"
-            """
         }
     }
 }
@@ -156,12 +154,12 @@ pipeline {
 
                   packer build -color=false \
                     -var 'vault_password_file=${vp}' \
-                    -var 'git_branch=${params.BB20_DEPLOY_BRANCH}' \
+                    -var 'git_branch=${params.BB20_APP_VERSION}' \
                     -var 'subnet_id=${params.SUBNET_ID}' \
                     -var 'env=${params.ENV}' \
-                    -var 'source_ami=${params.BB20_PLATINUM_AMI}' \
+                    -var 'source_ami=${BB20_PLATINUM_AMI}' \
                     -var 'release_version=${release_version}' \
-                    packer/build-ami.json
+                    packer/build_app_ami.json
                 """
               }
             }

--- a/Jenkinsfiles/Jenkinsfile.build_platinum_ami
+++ b/Jenkinsfiles/Jenkinsfile.build_platinum_ami
@@ -8,7 +8,7 @@ pipeline {
   agent {
     node {
       label ''
-      customWorkspace 'blue-button-build-ami'
+      customWorkspace 'blue-button-build-platinum-ami'
     }
   }
 
@@ -41,11 +41,6 @@ pipeline {
       defaultValue: "m3.medium",
       description: 'The class/size of the EC2 instance to launch.',
       name: 'INSTANCE_CLASS'
-    )
-    choice(
-      choices: 'dev\ntest\nimpl\nprod',
-      description: 'The environment to deploy the BB Platinum AMI to. Required.',
-      name: 'ENV'
     )
   }
 
@@ -115,7 +110,6 @@ pipeline {
                     -var 'vault_password_file=${vp}' \
                     -var 'git_branch=${params.BB20_APP_VERSION}' \
                     -var 'subnet_id=${params.SUBNET_ID}' \
-                    -var 'env=${params.ENV}' \
                     -var 'source_ami=${params.GDIT_GOLD_IMAGE_AMI_ID}' \
                     -var 'release_version=${release_version}' \
                     packer/build_platinum_ami.json 2>&1 | tee platinum_packer_output.txt

--- a/packer/build_platinum_ami.json
+++ b/packer/build_platinum_ami.json
@@ -29,8 +29,7 @@
               "ANSIBLE_VAULT_PASSWORD_FILE={{user `vault_password_file`}}"
             ],
             "extra_arguments": [
-              "-e git_branch={{user `git_branch`}}",
-              "-e env={{user `env`}}"
+              "-e git_branch={{user `git_branch`}}"
             ]
         }
     ]

--- a/playbook/build_app_ami/main.yml
+++ b/playbook/build_app_ami/main.yml
@@ -18,7 +18,12 @@
     - "./../../vars/all_var.yml"
 
   roles:
+    - ../../roles/nessus_update_key
+    - ../../roles/splunk
+    - ../../roles/aws
+    - ../../roles/app_user
     - ../../roles/app_prep
+    - ../../roles/app_logs
     - ../../roles/app_install
     - ../../roles/env_vars
     - ../../roles/new_relic

--- a/playbook/build_platinum_ami/main.yml
+++ b/playbook/build_platinum_ami/main.yml
@@ -5,16 +5,16 @@
   gather_facts: no
   vars:
     ansible_ssh_pipelining: no
-    env: "dev"
+#    env: "dev"
     azone: "az1"
     sub_zone: "app"
     sg_zone: "appserver"
-    env_az: "{{ env }}-{{ azone }}"
+#    env_az: "{{ env }}-{{ azone }}"
     splunk_target_layer: "app"
   vars_files:
     - "./../../vars/common.yml"
-    - "./../../vault/env/{{ env }}/vault.yml"
-    - "./../../vars/env/{{ env }}/env.yml"
+#    - "./../../vault/env/{{ env }}/vault.yml"
+#    - "./../../vars/env/{{ env }}/env.yml"
     - "./../../vars/all_var.yml"
 
   roles:
@@ -22,12 +22,6 @@
   #- ../../roles/swagger_ui_install
 
     - ../../roles/base_patch
-    - ../../roles/nessus_update_key
-    - ../../roles/splunk
-
     - ../../roles/selinux # selinux_state
-    - ../../roles/aws
     - ../../roles/app_tools
-    - ../../roles/app_user
-    - ../../roles/app_logs
     - ../../roles/python

--- a/vars/all_var.yml
+++ b/vars/all_var.yml
@@ -59,8 +59,9 @@
 
 
   # Remote user access account
-  remote_user_account: "{{ env_remote_user_account }}"
-  remote_admin_account: "{{ env_remote_admin_account }}"
+  # [JZ] - This is not needed, each env has the same emore user account, moving to common.yml
+  #remote_user_account: "{{ env_remote_user_account }}"
+  #remote_admin_account: "{{ env_remote_admin_account }}"
 
   ### DJANGO_SECRET_KEY:
   # 8 Character Prefix and Suffix

--- a/vars/common.yml
+++ b/vars/common.yml
@@ -15,6 +15,10 @@ common_cf_tags_business: "OEDA"
 common_cf_tags_application: "BlueButton"
 common_remote_user: "ec2-user"
 
+#Common user accounts
+remote_user_account: "ec2-user"
+remote_admin_account: "root"
+
 # Environment VPC Subnets
 
 common_repository: "https://github.com/transparenthealth/hhs_oauth_server"


### PR DESCRIPTION
This refactor of BLUEBUTTON-312 now builds an environment-agnostic AMI. It also adds and alters a new Jenkins pipeline script that I'll be using in BLUEBUTTON-314 as a jump-off point. 

This work supports two new PIPELINE jobs in Jenkins. 
BUILD_PLATINUM_AMI = Runs nightly and builds based from GDIT gold. Updates packages and installs prereqs (python). 
BUILD_BB_AMI = Runs manually, dynamically searches for platinum AMI from the above job if not specified, currently excepts and requires an ENV definition.  The output (AMI) is to be used for deploy. 

In BLUEBUTTON-314 I will alter the BUILD_BB_AMI job so that environment agnostic AMI's are built and will then perform ENV specific actions and var setting during the DEPLOY phase by utilizing the user_data script that is launched upon instance start (before the instance is placed into the ASG). 

Currently, this PR shaves 4 minutes from our build times for each environment and supports our current pipeline flow as it stands today, as well as supports my continued work in 314. 
