### PR TITLE
TF config files and Jenkins build job for Canary deploys.

### DIFF
--- a/Jenkinsfiles/Jenkinsfile.deploy_canary_ami
+++ b/Jenkinsfiles/Jenkinsfile.deploy_canary_ami
@@ -1,0 +1,223 @@
+def aws_creds = 'cbj-deploy'
+def private_key = ''
+def vault_pass = 'vault-pass'
+def backend_config = ''
+def terraform_vars = ''
+def release_version = ''
+def ami_id = ''
+
+ pipeline {
+  agent {
+    node {
+      label ''
+      customWorkspace 'blue-button-deploy-canary'
+    }
+  }
+
+   parameters {
+    string(
+      defaultValue: "*/master",
+      description: 'The branch of the deployment repo to use for the build.',
+      name: 'DEPLOY_BRANCH'
+    )
+    string(
+      defaultValue: "",
+      description: 'The Blue Button AMI id that will be used for the deployment.',
+      name: 'AMI_ID'
+    )
+    choice(
+      choices: 'impl\nprod',
+      description: 'The environment to deploy the canary to. Required.',
+      name: 'ENV'
+    )
+    string(
+      defaultValue: "0",
+      description: 'The number of Terraform to change actions expected.',
+      name: 'TF_EXPECT_CHANGES'
+    )
+  }
+
+   stages {
+    stage('Ensure ENV') {
+      steps {
+        script {
+          if (params.ENV == "") {
+            sh "exit 1"
+          }
+        }
+      }
+    }
+
+     stage('Ensure AMI ID') {
+      steps {
+        script {
+          if (ami_id == "") {
+            if (params.AMI_ID != "") {
+              ami_id = "${params.AMI_ID}"
+            } else {
+              sh "exit 1"
+            }
+          }
+        }
+      }
+    }
+
+     stage('Clear the working dir') {
+      steps {
+        dir('code') {
+          deleteDir()
+        }
+      }
+    }
+
+     stage('Checkout Repo') {
+      parallel {
+        stage('Checkout Deployment Repo') {
+          steps {
+            checkout([
+              $class: 'GitSCM',
+              branches: [[
+                name: "${params.DEPLOY_BRANCH}"
+              ]],
+              doGenerateSubmoduleConfigurations: false,
+              extensions: [[
+                $class: 'RelativeTargetDirectory',
+                relativeTargetDir: 'code'
+              ]],
+              userRemoteConfigs: [[
+                url: 'https://github.com/CMSgov/bluebutton-web-deployment.git'
+              ]]
+            ])
+          }
+        }
+        stage('Checkout TFENV Repo') {
+          steps {
+            checkout([
+              $class: 'GitSCM',
+              branches: [[
+                name: "*/master"
+              ]],
+              doGenerateSubmoduleConfigurations: false,
+              extensions: [[
+                $class: 'RelativeTargetDirectory',
+                relativeTargetDir: 'tfenv'
+              ]],
+              userRemoteConfigs: [[
+                url: 'https://github.com/tfutils/tfenv.git'
+              ]]
+            ])
+          }
+        }
+      }
+    }
+
+     stage('Install requirements') {
+      steps {
+        dir('code') {
+          script {
+            sh """
+              virtualenv -ppython2.7 venv
+              . venv/bin/activate
+
+               pip install --upgrade pip
+              pip install --upgrade cffi
+            """
+          }
+        }
+      }
+    }
+
+     stage('Install Terraform Version') {
+      steps {
+        dir('tfenv') {
+          script {
+            sh """
+              bin/tfenv install
+              terraform --version
+            """
+          }
+        }
+      }
+    }
+
+     stage('Set private key file') {
+      steps {
+        script {
+          private_key = "${params.ENV}-key"
+        }
+      }
+    }
+
+     stage('Determine terraform config files') {
+      steps {
+        script {
+          backend_config = "bb-backend-${params.ENV}_canary"
+          terraform_vars = "bb-tf-${params.ENV}_canary"
+        }
+      }
+    }
+
+     stage('Sanity check terraform plan') {
+      steps {
+        script {
+          dir('code') {
+            withAwsCli(credentialsId: aws_creds, defaultRegion: 'us-east-1') {
+              withCredentials([
+                file(credentialsId: backend_config, variable: 'bc'),
+                file(credentialsId: terraform_vars, variable: 'tv')
+              ]) {
+                sh """
+                  cd terraform/${params.ENV}_canary
+
+                   export TF_CLI_ARGS="-no-color"
+
+                   terraform init -backend-config=$bc
+
+                   TF_OUT=\$(terraform plan \
+                    -var-file=$tv \
+                    -var 'ami_id=$ami_id')
+
+                   TF_PLAN_CHECK=\$(echo "\$TF_OUT" | grep "Plan: 1 to add, ${params.TF_EXPECT_CHANGES} to change, 0 to destroy.")
+
+                   if [ -z "\$TF_PLAN_CHECK" ]
+                  then
+                    echo "Terraform plan does not match expectations."
+                    exit 1
+                  fi
+                """
+              }
+            }
+          }
+        }
+      }
+    }
+
+     stage('Deploy AMI') {
+      steps {
+        script {
+          dir('code') {
+            withAwsCli(credentialsId: aws_creds, defaultRegion: 'us-east-1') {
+              withCredentials([
+                file(credentialsId: backend_config, variable: 'bc'),
+                file(credentialsId: terraform_vars, variable: 'tv')
+              ]) {
+                sh """
+                  cd terraform/${params.ENV}_canary
+
+                   export TF_CLI_ARGS="-no-color"
+
+                   terraform init -backend-config=$bc
+                  terraform apply \
+                    -var-file=$tv \
+                    -var 'ami_id=$ami_id' \
+                    -var 'instance_type=${params.INSTANCE_CLASS}' \
+                    -auto-approve
+                """
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/Jenkinsfiles/Jenkinsfile.destroy_canary_ami
+++ b/Jenkinsfiles/Jenkinsfile.destroy_canary_ami
@@ -1,0 +1,202 @@
+def aws_creds = 'cbj-deploy'
+def private_key = ''
+def vault_pass = 'vault-pass'
+def backend_config = ''
+def terraform_vars = ''
+def release_version = ''
+def ami_id = ''
+
+pipeline {
+  agent {
+    node {
+      label ''
+      customWorkspace 'blue-button-deploy-canary'
+    }
+  }
+
+  parameters {
+    string(
+      defaultValue: "*/master",
+      description: 'The branch of the deployment repo to use for the job.',
+      name: 'DEPLOY_BRANCH'
+    )
+    string(
+      defaultValue: "",
+      description: 'The Blue Button AMI id that was used for deployment.',
+      name: 'AMI_ID'
+    )
+    choice(
+      choices: 'impl\nprod',
+      description: 'The environment which the canary resides in. Required.',
+      name: 'ENV'
+    )
+    string(
+      defaultValue: "",
+      description: 'The name of the instance to destroy. i.e. impl_canary_1',
+      name: 'INSTANCE_NAME'
+    )
+    string(
+      defaultValue: "0",
+      description: 'The number of Terraform to change actions expected.',
+      name: 'TF_EXPECT_CHANGES'
+    )
+  }
+
+  stages {
+    stage('Ensure ENV') {
+      steps {
+        script {
+          if (params.ENV == "") {
+            sh "exit 1"
+          }
+        }
+      }
+    }
+
+    stage('Clear the working dir') {
+      steps {
+        dir('code') {
+          deleteDir()
+        }
+      }
+    }
+
+    stage('Checkout Repo') {
+      parallel {
+        stage('Checkout Deployment Repo') {
+          steps {
+            checkout([
+              $class: 'GitSCM',
+              branches: [[
+                name: "${params.DEPLOY_BRANCH}"
+              ]],
+              doGenerateSubmoduleConfigurations: false,
+              extensions: [[
+                $class: 'RelativeTargetDirectory',
+                relativeTargetDir: 'code'
+              ]],
+              userRemoteConfigs: [[
+                url: 'https://github.com/CMSgov/bluebutton-web-deployment.git'
+              ]]
+            ])
+          }
+        }
+        stage('Checkout TFENV Repo') {
+          steps {
+            checkout([
+              $class: 'GitSCM',
+              branches: [[
+                name: "*/master"
+              ]],
+              doGenerateSubmoduleConfigurations: false,
+              extensions: [[
+                $class: 'RelativeTargetDirectory',
+                relativeTargetDir: 'tfenv'
+              ]],
+              userRemoteConfigs: [[
+                url: 'https://github.com/tfutils/tfenv.git'
+              ]]
+            ])
+          }
+        }
+      }
+    }
+
+    stage('Install requirements') {
+      steps {
+        dir('code') {
+          script {
+            sh """
+              virtualenv -ppython2.7 venv
+              . venv/bin/activate
+
+              pip install --upgrade pip
+              pip install --upgrade cffi
+            """
+          }
+        }
+      }
+    }
+
+    stage('Install Terraform Version') {
+      steps {
+        dir('tfenv') {
+          script {
+            sh """
+              bin/tfenv install
+              terraform --version
+            """
+          }
+        }
+      }
+    }
+
+    stage('Determine terraform config files') {
+      steps {
+        script {
+          backend_config = "bb-backend-${params.ENV}_canary"
+          terraform_vars = "bb-tf-${params.ENV}_canary"
+        }
+      }
+    }
+
+/*    stage('Sanity check terraform plan') {
+      steps {
+        script {
+          dir('code') {
+            withAwsCli(credentialsId: aws_creds, defaultRegion: 'us-east-1') {
+              withCredentials([
+                file(credentialsId: backend_config, variable: 'bc'),
+                file(credentialsId: terraform_vars, variable: 'tv')
+              ]) {
+                sh """
+                  cd terraform/${params.ENV}_canary
+
+                  export TF_CLI_ARGS="-no-color"
+
+                  terraform init -backend-config=$bc
+
+                  TF_OUT=\$(terraform destroy -target aws_instance.${params.ENV}_canary_app)
+
+                  TF_PLAN_CHECK=\$(echo "\$TF_OUT" | grep "Plan: 0 to add, ${params.TF_EXPECT_CHANGES} to change, 1 to destroy.")
+
+                  if [ -z "\$TF_PLAN_CHECK" ]
+                  then
+                    echo "Terraform plan does not match expectations."
+                    exit 1
+                  fi
+                """
+              }
+            }
+          }
+        }
+      }
+    }*/
+
+    stage('Destroy Canary Instance') {
+      steps {
+        script {
+          dir('code') {
+            withAwsCli(credentialsId: aws_creds, defaultRegion: 'us-east-1') {
+              withCredentials([
+                file(credentialsId: backend_config, variable: 'bc'),
+                file(credentialsId: terraform_vars, variable: 'tv')
+              ]) {
+                sh """
+                  cd terraform/${params.ENV}_canary
+
+                  export TF_CLI_ARGS="-no-color"
+
+                  terraform init -backend-config=$bc
+                  terraform destroy -var-file=$tv \
+                  -target aws_instance.${params.INSTANCE_NAME} \
+                  --auto-approve
+                """
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/terraform/impl_canary/backend.tf
+++ b/terraform/impl_canary/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    region = "us-east-1"
+  }
+}

--- a/terraform/impl_canary/main.tf
+++ b/terraform/impl_canary/main.tf
@@ -1,0 +1,46 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+data "template_file" "user_data" {
+  template = "${file("${path.module}/templates/user_data.tpl")}"
+
+  vars {
+    env    = "${lower(var.env)}"
+    bucket = "${var.app_config_bucket}"
+  }
+}
+
+
+
+resource "aws_instance" "impl_canary_app" {
+
+  ami           = "${var.ami_id}"
+  instance_type = "${var.instance_type}"
+  key_name      = "${var.key_name}"
+
+  subnet_id     = "${var.subnet_id}"
+  #user_data = "${file("${path.module}/templates/user_data")}"
+
+
+  user_data                   = "${data.template_file.user_data.rendered}"
+  iam_instance_profile        = "${var.iam_instance_profile}"
+
+  #   For canary, just needing one for ssh access: vpn
+
+  vpc_security_group_ids = [
+    "${var.vpc_sg_id}"
+  ]
+
+  associate_public_ip_address = false
+
+  tags {
+    Name = "bb-impl-canary"
+  }
+}
+
+#Assign Private IP to Output variable
+
+  output "private_ip" {
+    value = "${aws_instance.impl_canary_app.private_ip}"
+  }

--- a/terraform/impl_canary/templates/user_data.tpl
+++ b/terraform/impl_canary/templates/user_data.tpl
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+ set -e
+
+ exec 2> >(tee -a /var/log/boot.log >&2)
+
+ aws s3 cp s3://${bucket}/${env}/VAULT_PW .
+aws s3 cp s3://${bucket}/${env}/REPO_URI .
+
+ ansible-playbook --vault-password-file=./VAULT_PW \
+  -i "localhost" \
+  -e "env=${env}" \
+  -e "repo=$(cat REPO_URI)" \
+  /var/pyapps/hhs_o_server/env_config.yml
+
+ rm VAULT_PW REPO_URI

--- a/terraform/impl_canary/variables.tf
+++ b/terraform/impl_canary/variables.tf
@@ -1,0 +1,17 @@
+variable "env" {}
+
+variable "app_config_bucket" {}
+
+variable "ami_id" {}
+
+variable "instance_type" {}
+
+variable "key_name" {}
+
+variable "subnet_id" {}
+
+variable "iam_instance_profile" {}
+
+variable "vpc_sg_id" {}
+
+variable "instance_name" {}

--- a/terraform/prod_canary/backend.tf
+++ b/terraform/prod_canary/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "s3" {
+    region = "us-east-1"
+  }
+}

--- a/terraform/prod_canary/main.tf
+++ b/terraform/prod_canary/main.tf
@@ -1,0 +1,45 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+data "template_file" "user_data" {
+  template = "${file("${path.module}/templates/user_data.tpl")}"
+
+  vars {
+    env    = "${lower(var.env)}"
+    bucket = "${var.app_config_bucket}"
+  }
+}
+
+resource "aws_instance" "prod_canary_app" {
+
+  ami           = "${var.ami_id}"
+  instance_type = "${var.instance_type}"
+  key_name      = "${var.key_name}"
+
+  subnet_id     = "${var.subnet_id}"
+
+  #user_data = "${file("${path.module}/templates/user_data")}"
+
+
+  user_data                   = "${data.template_file.user_data.rendered}"
+  iam_instance_profile        = "${var.iam_instance_profile}"
+
+  #   For canary, just needing one for ssh access: vpn
+
+  vpc_security_group_ids = [
+    "${var.vpc_sg_id}"
+  ]
+
+  associate_public_ip_address = false
+
+  tags {
+    Name = "bb-prod-canary"
+  }
+}
+
+#Assign Private IP to Output variable
+
+  output "private_ip" {
+    value = "${aws_instance.prod_canary_app.private_ip}"
+  }

--- a/terraform/prod_canary/templates/user_data.tpl
+++ b/terraform/prod_canary/templates/user_data.tpl
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+ set -e
+
+ exec 2> >(tee -a /var/log/boot.log >&2)
+
+ aws s3 cp s3://${bucket}/${env}/VAULT_PW .
+aws s3 cp s3://${bucket}/${env}/REPO_URI .
+
+ ansible-playbook --vault-password-file=./VAULT_PW \
+  -i "localhost" \
+  -e "env=${env}" \
+  -e "repo=$(cat REPO_URI)" \
+  /var/pyapps/hhs_o_server/env_config.yml
+
+ rm VAULT_PW REPO_URI

--- a/terraform/prod_canary/variables.tf
+++ b/terraform/prod_canary/variables.tf
@@ -1,0 +1,17 @@
+variable "env" {}
+
+variable "app_config_bucket" {}
+
+variable "ami_id" {}
+
+variable "instance_type" {}
+
+variable "key_name" {}
+
+variable "subnet_id" {}
+
+variable "iam_instance_profile" {}
+
+variable "vpc_sg_id" {}
+
+variable "instance_name" {}


### PR DESCRIPTION
Summary: 

We wanted to automate and thus incorporate our canary deployments are Jenkins pipelines. To do this, I modified the existing TF configs that were previously used for manual TF'ing, 'variabalized' them and stored the variable and secrets within Jenkins credential manager. Each job takes an AMI as an argument (derived from the BUILD - BB APP AMI job) and deploys this AMI into its respective environment. During the build process, I am outputting the private IP address so you can connect (use respective keys, canary impl uses impl keys, etc.) when on the VPN. 

Django manage or collectstatic are NOT executed nor are they options within the pipeline. 

For now, canary instances need to be destroyed via the AWS console. I have a story to automate the destroy as time and priorities allow. There's certainly more we can do here and I'll be excited to circle back and expand on this. 

Jenkins Pipelines:
DEPLOY CANARY IMPL - https://cloudbeesjenkins.cms.gov/dev-master/job/Blue%20Button/job/DEPLOY%20-%20Canary%20AMI%20-%20IMPL/

DEPLOY CANARY PROD - https://cloudbeesjenkins.cms.gov/dev-master/job/Blue%20Button/job/DEPLOY%20-%20Canary%20AMI%20-%20PROD/

BUILD BB APP AMI (uses Platinum AMI as it's base) - https://cloudbeesjenkins.cms.gov/dev-master/job/Blue%20Button/job/BUILD%20-%20Blue%20Button%20API%20App/

