### PR TITLE
BLUEBUTTON-862 Make applications list public on next release to PROD

### DIFF
--- a/roles/nginx/files/nginx.conf
+++ b/roles/nginx/files/nginx.conf
@@ -55,7 +55,7 @@ http {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
 
-    location ~ /(health|{{ django_admin_redirector }}admin/|\.well-known/applications) {
+    location ~ /(health|{{ django_admin_redirector }}admin/) {
       real_ip_header   X-Forwarded-For;
       set_real_ip_from 10.0.0.0/8;
 


### PR DESCRIPTION
Summary:

This REMOVES the \.well-known/applications endpoint from being restricted by IP address range in the NGINX configuration.

Controlling the enabling and disabling of this end-point will make use of a feature switch in the application instead. 