### PR TITLE
Bluebutton 858

### DIFF
--- a/roles/splunk/tasks/main.yml
+++ b/roles/splunk/tasks/main.yml
@@ -12,3 +12,8 @@
   shell: |
     /opt/splunkforwarder/bin/splunk stop
     /opt/splunkforwarder/bin/splunk clone-prep-clear-config
+
+- name: "Restart splunk"
+  become_user: "{{ remote_admin_account }}"
+  shell: |
+    /opt/splunkforwarder/bin/splunk start

--- a/roles/splunk/tasks/main.yml
+++ b/roles/splunk/tasks/main.yml
@@ -6,14 +6,14 @@
     src: "../templates/splunk_deployment_conf.j2"
     dest: "/opt/splunkforwarder/etc/system/local/deploymentclient.conf"
 
-- name: "initialize splunk configuration"
+- name: "Stop and initialize splunk configuration"
   become_user: "{{ remote_admin_account }}"
   become: yes
   shell: |
     /opt/splunkforwarder/bin/splunk stop
     /opt/splunkforwarder/bin/splunk clone-prep-clear-config
 
-- name: "Restart splunk"
+- name: "Start splunk"
   become_user: "{{ remote_admin_account }}"
   shell: |
     /opt/splunkforwarder/bin/splunk start


### PR DESCRIPTION
This PR starts the Splunk service after the config is initialized. Previously this step was done during the build phase of the environment AMI. So that the next time this was deployed, Splunk is set to start automatically. This task has moved to the deployment phase (executed on instance launch) and therefore a start of the service is required after the config initialization. 

One line change. start splunk. :)