### PR TITLE
BLUEBUTTON-821: Slack Notifications

### DIFF
--- a/Jenkinsfiles/Jenkinsfile.build_app_ami
+++ b/Jenkinsfiles/Jenkinsfile.build_app_ami
@@ -3,7 +3,7 @@ def BB20_PLATINUM_AMI_ID = ''
 def release_version = ''
 def vault_pass = 'vault-pass'
 def aws_creds = 'cbj-deploy'
-def slack_channel = '#bluebutton-alerts'
+def helpers
 
 pipeline {
   agent {
@@ -42,6 +42,15 @@ pipeline {
   }
 
   stages {
+    stage('Notify') {
+      steps {
+        script {
+          helpers = load "Jenkinsfiles/helpers.groovy"
+          helpers.slackNotify "STARTING"
+        }
+      }
+    }
+
     stage('Set release_version var') {
       steps {
         script {
@@ -54,10 +63,6 @@ pipeline {
         }
       }
     }
-
-/*
-# THIS IS WHERE WE WILL ADD SLACK NOTIFICATIONS ONCE SLACK IS ONLINE
-*/
 
     stage('Checkout') {
       steps {
@@ -130,7 +135,26 @@ pipeline {
     }
   }
 
-/*
-# THIS IS WHERE WE WILL ADD SLACK NOTIFICATIONS ONCE SLACK IS ONLINE
-*/
+  post {
+      success {
+        script {
+          helpers.slackNotify("SUCESS", 'good')
+        }
+      }
+
+      failure {
+        script {
+          try {
+            helpers.slackNotify("FAILED!", 'bad')
+          } catch (err) {
+            emailext body: "A CBJ job failed and we couldn't notify Slack.\n${BUILD_URL}", subject: 'CBJ Build Failure', to: 'bluebutton-dev-alert@fearsol.com'
+          }
+        }
+      }
+
+      always {
+        // Cleanup the workspace
+        deleteDir()
+      }
+  }
 }

--- a/Jenkinsfiles/Jenkinsfile.build_platinum_ami
+++ b/Jenkinsfiles/Jenkinsfile.build_platinum_ami
@@ -2,7 +2,7 @@ def private_key = ''
 def vault_pass = 'vault-pass'
 def aws_creds = 'cbj-deploy'
 def release_version = ''
-def slack_channel = '#bluebutton-alerts'
+def helpers
 
 pipeline {
   agent {
@@ -45,7 +45,16 @@ pipeline {
   }
 
   stages {
-    stage('Ensure BB20_APP_VERSION, GDIT_GOLD_IMAGE_AMI_ID and SUBNET_ID') {
+    stage('Notify') {
+      steps {
+        script {
+          helpers = load "Jenkinsfiles/helpers.groovy"
+          helpers.slackNotify "STARTING"
+        }
+      }
+    }
+
+    stage('Ensure Params') {
       steps {
         sh """
         if [ -z "${params.BB20_APP_VERSION}" ] || [ -z "${params.GDIT_GOLD_IMAGE_AMI_ID}" ] || [ -z "${params.SUBNET_ID}" ]
@@ -69,7 +78,7 @@ pipeline {
       }
     }
 
-    stage('Checkout bluebutton-web-deployment') {
+    stage('Setup and Checkout Deployment Repo') {
       steps {
         checkout([
           $class: 'GitSCM',
@@ -85,6 +94,9 @@ pipeline {
             url: 'https://github.com/CMSgov/bluebutton-web-deployment.git'
           ]]
         ])
+        script {
+            helpers = load "Jenkinsfiles/helpers.groovy"
+        }
       }
     }
 
@@ -145,8 +157,26 @@ pipeline {
     }
   }
 
-/*
-# THIS IS WHERE WE WILL ADD SLACK NOTIFICATIONS ONCE SLACK IS ONLINE
-*/
+  post {
+      success {
+        script {
+          helpers.slackNotify("SUCCESS", 'good')
+        }
+      }
 
+      failure {
+        script {
+          try {
+            helpers.slackNotify("FAILED!", 'bad')
+          } catch (err) {
+            emailext body: "A CBJ job failed and we couldn't notify Slack.\n${BUILD_URL}", subject: 'CBJ Build Failure', to: 'bluebutton-dev-alert@fearsol.com'
+          }
+        }
+      }
+
+      always {
+        // Cleanup the workspace
+        deleteDir()
+      }
+  }
 }

--- a/Jenkinsfiles/Jenkinsfile.deploy_ami
+++ b/Jenkinsfiles/Jenkinsfile.deploy_ami
@@ -5,6 +5,7 @@ def backend_config = ''
 def terraform_vars = ''
 def release_version = ''
 def ami_id = ''
+def helpers
 
 pipeline {
   agent {
@@ -53,6 +54,15 @@ pipeline {
   }
 
   stages {
+    stage('Notify') {
+      steps {
+        script {
+          helpers = load "Jenkinsfiles/helpers.groovy"
+          helpers.slackNotify "STARTING - Env:${params.ENV}"
+        }
+      }
+    }
+
     stage('Ensure ENV') {
       steps {
         script {
@@ -99,27 +109,6 @@ pipeline {
       steps {
         dir('code') {
           deleteDir()
-        }
-      }
-    }
-
-    stage('Notify HipChat') {
-      steps {
-        withCredentials([
-          string(credentialsId: 'hipchat-room', variable: 'room'),
-          string(credentialsId: 'hipchat-server', variable: 'server'),
-          string(credentialsId: 'hipchat-token', variable: 'token')
-        ]) {
-          hipchatSend(
-            color: 'GRAY',
-            notify: true,
-            message: "STARTED: ${env.JOB_NAME} [${params.ENV}]",
-            room: room,
-            sendAs: '',
-            server: server,
-            token: token,
-            v2enabled: true
-          )
         }
       }
     }
@@ -336,24 +325,8 @@ pipeline {
 
   post {
     success {
-      withCredentials([
-        string(credentialsId: 'hipchat-room', variable: 'room'),
-        string(credentialsId: 'hipchat-server', variable: 'server'),
-        string(credentialsId: 'hipchat-token', variable: 'token')
-      ]) {
-        hipchatSend(
-            color: 'GREEN',
-            notify: true,
-            message: "SUCCESS: ${env.JOB_NAME} [${params.ENV}]",
-            room: room,
-            sendAs: '',
-            server: server,
-            token: token,
-            v2enabled: true
-        )
-      }
-
       script {
+        helpers.slackNotify("SUCCESS - Env:${params.ENV}", 'good')
         if (params.ENV == "prod" || params.ENV == "impl") {
           withAwsCli(credentialsId: aws_creds, defaultRegion: 'us-east-1') {
             release_version = sh(
@@ -378,21 +351,12 @@ pipeline {
     }
 
     failure {
-      withCredentials([
-        string(credentialsId: 'hipchat-room', variable: 'room'),
-        string(credentialsId: 'hipchat-server', variable: 'server'),
-        string(credentialsId: 'hipchat-token', variable: 'token')
-      ]) {
-        hipchatSend(
-          color: 'RED',
-          notify: true,
-          message: "FAILED: ${env.JOB_NAME} [${params.ENV}]",
-          room: room,
-          sendAs: '',
-          server: server,
-          token: token,
-          v2enabled: true
-        )
+      script {
+        try {
+          helpers.slackNotify("FAILED! - Env:${params.ENV}", 'bad')
+        } catch (err) {
+           emailext body: "A CBJ job failed and we couldn't notify Slack.\n${BUILD_URL}", subject: 'CBJ Build Failure', to: 'bluebutton-dev-alert@fearsol.com'
+        }
       }
     }
   }

--- a/Jenkinsfiles/Jenkinsfile.deploy_canary_ami
+++ b/Jenkinsfiles/Jenkinsfile.deploy_canary_ami
@@ -5,6 +5,7 @@ def backend_config = ''
 def terraform_vars = ''
 def release_version = ''
 def ami_id = ''
+def helpers
 
  pipeline {
   agent {
@@ -38,6 +39,15 @@ def ami_id = ''
   }
 
    stages {
+     stage('Notify') {
+       steps {
+         script {
+           helpers = load "Jenkinsfiles/helpers.groovy"
+           helpers.slackNotify "STARTING - Env:${params.ENV}"
+         }
+       }
+     }
+
     stage('Ensure ENV') {
       steps {
         script {
@@ -218,6 +228,29 @@ def ami_id = ''
           }
         }
       }
+    }
+  }
+
+  post {
+    success {
+      script {
+        helpers.slackNotify("SUCCESS", 'good')
+      }
+    }
+
+    failure {
+      script {
+        try {
+          helpers.slackNotify("FAILED!", 'bad')
+        } catch (err) {
+          emailext body: "A CBJ job failed and we couldn't notify Slack.\n${BUILD_URL}", subject: 'CBJ Build Failure', to: 'bluebutton-dev-alert@fearsol.com'
+        }
+      }
+    }
+
+    always {
+      // Cleanup the workspace
+      deleteDir()
     }
   }
 }

--- a/Jenkinsfiles/helpers.groovy
+++ b/Jenkinsfiles/helpers.groovy
@@ -1,0 +1,29 @@
+#!/usr/bin/env groovy
+
+// Send a message to Slack
+def slackNotify(message, status='unknown', channel='blue-button-api-alert') {
+  switch (status) {
+    case 'good':
+      slack_color = 'good'
+      break
+    case 'bad':
+      slack_color = 'danger'
+      break
+    default:
+      slack_color = null
+      break
+  }
+
+  withCredentials([string(credentialsId: 'bb20-slack-token', variable: 'slack_token')]) {
+    if (env.DISABLE_SLACK_ALERTS != 'true') {
+      slackSend message: "${message}\n${env.JOB_NAME} ${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)",
+        color: slack_color,
+        failOnError: false,
+        teamDomain: 'cmsgov',
+        channel: channel,
+        token: slack_token
+    }
+  }
+}
+
+return this


### PR DESCRIPTION
Summary: 
This PR adds Slack notifications sent to the cmsgov #blue-button-api-alert channel for our BUILD and DEPLOY jobs within Jenkins. 

Details:
The Jenkins jobs covered by this PR are:
1. BUILD - Platinum AMI
2. BUILD - Blue Button API App
3. DEPLOY - BB AMI (all envs)
4. DEPLOY - Canary AMI (all envs)

Stages with Notices
1. Job Starting - Grey Color - includes a link to the job. 
2. Job Finished State (SUCCESS (green) vs. FAILURE (red)) - includes a link to the job

Note: I'm using a newly minted helpers.groovy file to reuse components in the future. 

Testing:
I tested all 4 Jenkins jobs and you can see the results in #blue-button-api-alert. I also added a catch-all if slack notices are unable to send, to fire off an email to bluebutton-dev-alert@fearsol.com so we can notice that if it the integration breaks. 