### PR TITLE
BLUEBUTTON-882: Enable CD to DEV Environment

### DIFF
--- a/Jenkinsfiles/Jenkinsfile.build_app_ami
+++ b/Jenkinsfiles/Jenkinsfile.build_app_ami
@@ -16,12 +16,12 @@ pipeline {
   parameters {
     string(
       defaultValue: "master",
-      description: 'The branch of the application repo to build. Required.',
+      description: 'The branch of the application repo to build. Required. Defaults to master.',
       name: 'BB20_APP_VERSION'
     )
     string(
       defaultValue: "master",
-      description: 'The branch of the deployment repo to use for the build.',
+      description: 'The branch of the deployment repo to use for the build. Default to master. Required. Defaults to master.',
       name: 'BB20_DEPLOY_BRANCH'
     )
     string(
@@ -31,17 +31,37 @@ pipeline {
     )
     string(
       defaultValue: "subnet-81ecfbab",
-      description: 'The subnet ID where the build server will be launched.',
+      description: 'The subnet ID where the build server will be launched. You are safe to leave this. We are currently use a DEV subnet for builds.',
       name: 'SUBNET_ID'
     )
-    string(
-      defaultValue: "m3.medium",
-      description: 'The class/size of the ec2 instance to launch.',
-      name: 'INSTANCE_CLASS'
+    choice(
+      choices: 'dev\ntest\nimpl\nprod',
+      description: 'The environment to deploy to. Default to DEV.',
+      name: 'ENV'
+    )
+    choice(
+      choices: 'no\nyes',
+      description: 'Should we run database migrations on deploy? Default to Yes.',
+      name: 'MIGRATE'
+    )
+    choice(
+      choices: 'yes\nno',
+      description: 'Should we run collectstatic on deploy? Default to No.',
+      name: 'COLLECT_STATIC'
     )
   }
 
   stages {
+    stage('Ensure BRANCH, ENV, AMI_ID and SUBNET_ID') {
+      steps {
+        sh """
+        if [ -z "${params.BRANCH}" ] || [ -z "${params.ENV}" ] || [ -z "${params.AMI_ID}" ] || [ -z "${params.SUBNET_ID}" ]
+        then
+          exit 1
+        fi
+        """
+      }
+    }
     stage('Notify') {
       steps {
         script {
@@ -126,19 +146,37 @@ pipeline {
                     -var 'source_ami=${BB20_PLATINUM_AMI}' \
                     -var 'release_version=${release_version}' \
                     packer/build_app_ami.json
+
                 """
+                BUILD_AMI_ID = sh(
+                script: "cat manifest.json | jq -r .builds[0].artifact_id |  cut -d':' -f2",
+                returnStdout: true
+                ).trim()
+                println("BUILD_AMI_ID: = ${BUILD_AMI_ID}")
               }
             }
           }
         }
       }
     }
+
+    stage ('Deploy to DEV') {
+      when {
+        allOf {
+          environment name: 'BB20_APP_VERSION', value: 'master'; environment name: 'ENV', value: 'dev'
+        }
+      }
+        steps {
+        echo "Condition met for CD to DEV"
+        build job: 'DEPLOY - BB AMI', propagate: false, wait: false, parameters: [[$class: 'StringParameterValue', name: 'DEPLOY_BRANCH', value: "${BB20_DEPLOY_BRANCH}"], [$class: 'StringParameterValue', name: 'AMI_ID', value: "${BUILD_AMI_ID}"], [$class: 'StringParameterValue', name: 'ENV', value: "${ENV}"], [$class: 'StringParameterValue', name: 'MIGRATE', value: "${MIGRATE}"], [$class: 'StringParameterValue', name: 'COLLECT_STATIC', value: "${COLLECT_STATIC}"], [$class: 'StringParameterValue', name: 'TF_EXPECT_CHANGES', value: "3"]]
+        }
+    }
   }
 
   post {
       success {
         script {
-          helpers.slackNotify("SUCESS", 'good')
+          helpers.slackNotify("SUCCESS", 'good')
         }
       }
 

--- a/Jenkinsfiles/Jenkinsfile.build_app_ami
+++ b/Jenkinsfiles/Jenkinsfile.build_app_ami
@@ -41,12 +41,12 @@ pipeline {
     )
     choice(
       choices: 'no\nyes',
-      description: 'Should we run database migrations on deploy? Default to Yes.',
+      description: 'Should we run database migrations on deploy? Default to No.',
       name: 'MIGRATE'
     )
     choice(
       choices: 'yes\nno',
-      description: 'Should we run collectstatic on deploy? Default to No.',
+      description: 'Should we run collectstatic on deploy? Default to Yes.',
       name: 'COLLECT_STATIC'
     )
   }

--- a/Jenkinsfiles/Jenkinsfile.deploy_ami
+++ b/Jenkinsfiles/Jenkinsfile.deploy_ami
@@ -243,7 +243,7 @@ pipeline {
                   TF_HIGHCPU_CHECK=\$(echo "\$TF_OUT" | grep "aws_autoscaling_policy.high-cpu.*(new resource required)")
                   TF_LOWCPU_CHECK=\$(echo "\$TF_OUT" | grep "aws_autoscaling_policy.low-cpu.*(new resource required)")
 
-                  TF_PLAN_CHECK=\$(echo "\$TF_OUT" | grep "Plan: 4 to add, ${params.TF_EXPECT_CHANGES} to change, 2 to destroy.")
+                  TF_PLAN_CHECK=\$(echo "\$TF_OUT" | grep "Plan: 4 to add, ${params.TF_EXPECT_CHANGES} to change, 4 to destroy.")
 
                   if [ -z "\$TF_ASG_CHECK" ] || [ -z "\$TF_LC_CHECK" ] || [ -z "\$TF_AMI_CHECK" ] || [ -z "\$TF_HIGHCPU_CHECK" ] || [ -z "\$TF_LOWCPU_CHECK" ] || [ -z "\$TF_PLAN_CHECK" ]
                   then

--- a/Jenkinsfiles/Jenkinsfile.deploy_ami
+++ b/Jenkinsfiles/Jenkinsfile.deploy_ami
@@ -243,7 +243,7 @@ pipeline {
                   TF_HIGHCPU_CHECK=\$(echo "\$TF_OUT" | grep "aws_autoscaling_policy.high-cpu.*(new resource required)")
                   TF_LOWCPU_CHECK=\$(echo "\$TF_OUT" | grep "aws_autoscaling_policy.low-cpu.*(new resource required)")
 
-                  TF_PLAN_CHECK=\$(echo "\$TF_OUT" | grep "Plan: 4 to add, ${params.TF_EXPECT_CHANGES} to change, 4 to destroy.")
+                  TF_PLAN_CHECK=\$(echo "\$TF_OUT" | grep "Plan: 4 to add, ${params.TF_EXPECT_CHANGES} to change, 2 to destroy.")
 
                   if [ -z "\$TF_ASG_CHECK" ] || [ -z "\$TF_LC_CHECK" ] || [ -z "\$TF_AMI_CHECK" ] || [ -z "\$TF_HIGHCPU_CHECK" ] || [ -z "\$TF_LOWCPU_CHECK" ] || [ -z "\$TF_PLAN_CHECK" ]
                   then

--- a/Jenkinsfiles/Jenkinsfile.deploy_ami
+++ b/Jenkinsfiles/Jenkinsfile.deploy_ami
@@ -216,7 +216,7 @@ pipeline {
       }
     }
 
-/*    stage('Sanity check terraform plan') {
+    stage('Sanity check terraform plan') {
       steps {
         script {
           dir('code') {
@@ -256,7 +256,7 @@ pipeline {
           }
         }
       }
-    }*/
+    }
 
     stage('Deploy AMI') {
       steps {

--- a/Jenkinsfiles/Jenkinsfile.deploy_ami
+++ b/Jenkinsfiles/Jenkinsfile.deploy_ami
@@ -216,7 +216,7 @@ pipeline {
       }
     }
 
-    stage('Sanity check terraform plan') {
+/*    stage('Sanity check terraform plan') {
       steps {
         script {
           dir('code') {
@@ -256,7 +256,7 @@ pipeline {
           }
         }
       }
-    }
+    }*/
 
     stage('Deploy AMI') {
       steps {

--- a/packer/build_app_ami.json
+++ b/packer/build_app_ami.json
@@ -35,5 +35,14 @@
               "-e git_branch={{user `git_branch`}}"
             ]
         }
+    ],
+    "post-processors": [
+      [
+        {
+          "output": "manifest.json",
+          "strip_path": true,
+          "type": "manifest"
+        }
+      ]
     ]
 }

--- a/packer/build_app_ami.json
+++ b/packer/build_app_ami.json
@@ -37,12 +37,10 @@
         }
     ],
     "post-processors": [
-      [
         {
           "output": "manifest.json",
           "strip_path": true,
           "type": "manifest"
         }
-      ]
     ]
 }


### PR DESCRIPTION
**Summary:**
We want to continuously deploy changes to master to the DEV environment. Our Build App Jenkins job will now poll for changes to the bluebutton-web-server repo and check for changes to master. If detected, the job will fire which proceeds with the building of an environment-agnostic AMI. If specific conditions are met, a universal downstream deploy job is triggered with the deploy parameters needed to proceed. The downstream job is referenced in the console output and gets fired off while this job will complete and does not wait for the deploy job. 

**Details:**
The CBJ Job can be found here: https://cloudbeesjenkins.cms.gov/dev-master/job/Blue%20Button/job/BUILD%20-%20Blue%20Button%20API%20App/

You can set the following parameters:
BB20_APP_VERSION - Branch of bluebutton-web-server to build. 
BB20_DEPLOY_BRANCH - Branch of bluebutton-web-deployment to use
BB20_PLATINUM_AMI_ID - Platinum AMI to use. Leave blank to use latest automatically. 
SUBNET_ID - Subnet in AWS to use to launch build services. Using DEV until we have a shared VPC. 
ENV - Set the environment to deploy to. Defaults to DEV. 
MIGRATE: Specify if Django migrations are necessary. Defaults to No. 
COLLECT_STATIC: Specify if Django collectstatic is necessary. Defaults to Yes. 

I intend on adding additional conditional downstream jobs to support the other environments. This PR only adds the ability for DEV and adjusts the pipeline to account for the exra paramters needed and sets it to poll SCM for changes. 

Note: I added a post processor to the packer build config so that a manifest of the job is provided. We use this to get the AMI ID to pass to the deploy job. 

Supporting documentation can be found here, this document is a work in progress: https://confluence.cms.gov/display/BB/%5BWIP%5D+Blue+Button+2.0+API+-+CBJ+Pipeline+Overview

