### PR TITLE
BLUEBUTTON-882 - Changing Param Sanity Check

### DIFF
--- a/Jenkinsfiles/Jenkinsfile.build_app_ami
+++ b/Jenkinsfiles/Jenkinsfile.build_app_ami
@@ -52,10 +52,10 @@ pipeline {
   }
 
   stages {
-    stage('Ensure BRANCH, ENV, AMI_ID and SUBNET_ID') {
+    stage('Ensure BRANCH, ENV, and SUBNET_ID') {
       steps {
         sh """
-        if [ -z "${params.BRANCH}" ] || [ -z "${params.ENV}" ] || [ -z "${params.AMI_ID}" ] || [ -z "${params.SUBNET_ID}" ]
+        if [ -z "${params.BB20_APP_VERSION}" ] || [ -z "${params.ENV}" ] || [ -z "${params.SUBNET_ID}" ]
         then
           exit 1
         fi


### PR DESCRIPTION
I forgot to update the parameters used in the sanity check. This step ensures the necessary parameters are present before continuing the build. I had to modify the param values to match the ones actually being passed. Performed test, this works in the pipeline. 