### PR TITLE
BLUEBUTTON-1175 Add datapoints_to_alarm setting for cloudwatch alarms

### DIFF
--- a/terraform/modules/elb_http_alarms/main.tf
+++ b/terraform/modules/elb_http_alarms/main.tf
@@ -25,6 +25,7 @@ resource "aws_cloudwatch_metric_alarm" "healthy_hosts" {
   treat_missing_data = "breaching"
   alarm_actions      = ["${var.cloudwatch_notification_arn}"]
   ok_actions         = ["${var.cloudwatch_notification_arn}"]
+  datapoints_to_alarm = "1"
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_latency" {
@@ -49,6 +50,7 @@ resource "aws_cloudwatch_metric_alarm" "high_latency" {
   treat_missing_data = "breaching"
   alarm_actions      = ["${var.cloudwatch_notification_arn}"]
   ok_actions         = ["${var.cloudwatch_notification_arn}"]
+  datapoints_to_alarm = "1"
 }
 
 resource "aws_cloudwatch_metric_alarm" "spillover_count" {
@@ -73,6 +75,7 @@ resource "aws_cloudwatch_metric_alarm" "spillover_count" {
   treat_missing_data = "notBreaching"
   alarm_actions      = ["${var.cloudwatch_notification_arn}"]
   ok_actions         = ["${var.cloudwatch_notification_arn}"]
+  datapoints_to_alarm = "1"
 }
 
 resource "aws_cloudwatch_metric_alarm" "surge_queue_exceeded" {
@@ -99,6 +102,7 @@ resource "aws_cloudwatch_metric_alarm" "surge_queue_exceeded" {
 
   alarm_actions = ["${var.cloudwatch_notification_arn}"]
   ok_actions    = ["${var.cloudwatch_notification_arn}"]
+  datapoints_to_alarm = "1"
 }
 
 resource "aws_cloudwatch_metric_alarm" "httpcode_backend_4xx" {
@@ -123,6 +127,7 @@ resource "aws_cloudwatch_metric_alarm" "httpcode_backend_4xx" {
 
   alarm_actions = ["${var.cloudwatch_notification_arn}"]
   ok_actions    = ["${var.cloudwatch_notification_arn}"]
+  datapoints_to_alarm = "1"
 }
 
 resource "aws_cloudwatch_metric_alarm" "httpcode_backend_5xx" {
@@ -147,6 +152,7 @@ resource "aws_cloudwatch_metric_alarm" "httpcode_backend_5xx" {
 
   alarm_actions = ["${var.cloudwatch_notification_arn}"]
   ok_actions    = ["${var.cloudwatch_notification_arn}"]
+  datapoints_to_alarm = "1"
 }
 
 resource "aws_cloudwatch_metric_alarm" "httpcode_elb_5xx" {
@@ -171,4 +177,5 @@ resource "aws_cloudwatch_metric_alarm" "httpcode_elb_5xx" {
 
   alarm_actions = ["${var.cloudwatch_notification_arn}"]
   ok_actions    = ["${var.cloudwatch_notification_arn}"]
+  datapoints_to_alarm = "1"
 }


### PR DESCRIPTION
Summary:
This add the datapoints_to_alarm setting to cloudwatch alarms. This fixes an issue where this variable is unset when created by terraform, but is set when saving an alarm via the AWS console. This can unexpectedly cause the terraform expected changes to differ during deployments.