### PR TITLE
BLUEBUTTON-1083 Increase timeout for ASG instances to be healthy

### DIFF
--- a/terraform/modules/asg/main.tf
+++ b/terraform/modules/asg/main.tf
@@ -95,6 +95,7 @@ resource "aws_autoscaling_group" "main" {
   min_elb_capacity          = "${var.asg_min}"
   health_check_grace_period = 300
   health_check_type         = "ELB"
+  wait_for_capacity_timeout = "20m"
   vpc_zone_identifier       = ["${data.aws_subnet_ids.app.ids}"]
   launch_configuration      = "${aws_launch_configuration.app.name}"
   load_balancers            = ["${data.aws_elb.elb.name}"]


### PR DESCRIPTION
Summary:

This increased the timeout value from "10m" to "20m" for ASG creation timeout.