### PR TITLE
BLUEBUTTON-1275 SELinux enforcing setup fixup

### DIFF
--- a/playbook/appherd/roles/create_certstore/tasks/main.yml
+++ b/playbook/appherd/roles/create_certstore/tasks/main.yml
@@ -10,7 +10,7 @@
   become: yes
   file:
     dest: "{{ app_pyapp_home }}/certstore"
-    mode: 0755
+    mode: 0750
     owner: "{{ app_pyapps_user }}"
     group: "{{ app_group }}"
     recurse: yes

--- a/roles/app_install/tasks/main.yml
+++ b/roles/app_install/tasks/main.yml
@@ -90,6 +90,17 @@
 
 - import_tasks: ./../appherd/roles/create_certstore/tasks/main.yml
 
+- name: "Create run dir for service .sock/.pid files"
+  become_user: "{{ remote_admin_account }}"
+  become: yes
+  file:
+    dest: "{{ app_pyapp_home }}/run"
+    mode: 0750
+    owner: "{{ app_pyapps_user }}"
+    group: "{{ app_group }}"
+    recurse: yes
+    state: directory
+
 # change ownership of files
 - name: "Update file ownership"
   become_user: "{{ remote_admin_account }}"


### PR DESCRIPTION
### Change Details

This  includes changes needed to run our web server RHEL instances in SELinux "enforcing" state.

NOTE:  This continues work from a previous PR: https://github.com/CMSgov/bluebutton-web-deployment/pull/1374 
The creation of a /run directory via Ansible was needed. 
I also made an improvement to the file mode permissions of the certstore directory.
  
SELinux reference for RHEL 7:  https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/selinux_users_and_administrators_guide/index

### Acceptance Validation

That this change will set the SELinux "enforcing" state RHEL instances and that the website functions normally afterward.
During testing, we will need to review the /var/log/audit/audit.log file for blocked actions.

### Feedback Requested

<!-- What type of feedback you want from your reviewers? -->

### External References

<!-- For example: replace xxx with the JIRA ticket number: -->

- [BLUEBUTTON-1275](https://jira.cms.gov/browse/BLUEBUTTON-1275)

