### PR TITLE
BLUEBUTTON-1349: Platinum AMI Build Bug / Imrovements

### DIFF
--- a/Jenkinsfiles/Jenkinsfile.build_platinum_ami
+++ b/Jenkinsfiles/Jenkinsfile.build_platinum_ami
@@ -57,11 +57,18 @@ pipeline {
     stage('Acquire Latest Gold AMI'){
       steps {
         script {
-          GDIT_GOLD_IMAGE_AMI_ID = sh(returnStdout: true, script: """/usr/local/bin/aws ec2 describe-images --filters \
-          'Name=name,Values=\"EAST-RH 7-? Gold Image V.1.?? (HVM) ??-??-??\"' \
-          'Name=state,Values=available' --region us-east-1 --output json | \
-          jq -r '.Images | sort_by(.CreationDate) | last(.[]).ImageId'""")
-          echo "LATEST GOLD IMAGE AMI: ${GDIT_GOLD_IMAGE_AMI_ID}"
+          if (params.GDIT_GOLD_IMAGE_AMI_ID == '') {
+            GDIT_GOLD_IMAGE_AMI_ID = sh(returnStdout: true, script: """/usr/local/bin/aws ec2 describe-images --filters \
+            'Name=name,Values=\"EAST-RH 7-? Gold Image V.1.?? (HVM) ??-??-??\"' \
+            'Name=state,Values=available' --region us-east-1 --output json | \
+            jq -r '.Images | sort_by(.CreationDate) | last(.[]).ImageId'"""
+            ).trim()
+            echo "LATEST GOLD IMAGE AMI: ${GDIT_GOLD_IMAGE_AMI_ID}" 
+          }
+          else {
+            GDIT_GOLD_IMAGE_AMI_ID = params.GDIT_GOLD_IMAGE_AMI_ID
+            echo "USING GOLD IMAGE AMI: ${GDIT_GOLD_IMAGE_AMI_ID}" 
+          }
         }
       }
     }
@@ -69,7 +76,7 @@ pipeline {
     stage('Ensure Params') {
       steps {
         sh """
-        if [ -z "${params.BB20_APP_VERSION}" ] || [ -z "${params.GDIT_GOLD_IMAGE_AMI_ID}" ] || [ -z "${params.SUBNET_ID}" ]
+        if [ -z "${params.BB20_APP_VERSION}" ] || [ -z "${GDIT_GOLD_IMAGE_AMI_ID}" ] || [ -z "${params.SUBNET_ID}" ]
         then
           exit 1
         fi
@@ -135,7 +142,7 @@ pipeline {
                       -var 'vault_password_file=${vp}' \
                       -var 'git_branch=${params.BB20_APP_VERSION}' \
                       -var 'subnet_id=${params.SUBNET_ID}' \
-                      -var 'source_ami=${params.GDIT_GOLD_IMAGE_AMI_ID}' \
+                      -var 'source_ami=${GDIT_GOLD_IMAGE_AMI_ID}' \
                       -var 'release_version=${release_version}' \
                       packer/build_platinum_ami.json 2>&1 | tee platinum_packer_output.txt
                   """

--- a/Jenkinsfiles/Jenkinsfile.build_platinum_ami
+++ b/Jenkinsfiles/Jenkinsfile.build_platinum_ami
@@ -108,24 +108,29 @@ pipeline {
               withCredentials([
                 file(credentialsId: vault_pass, variable: 'vp')
               ]) {
-                sh """
-                  virtualenv -ppython3 venv
-                  . venv/bin/activate
+                try {
+                  sh """
+                    virtualenv -ppython3 venv
+                    . venv/bin/activate
 
-                  pip install --upgrade pip
-                  pip install --upgrade cffi
+                    pip install --upgrade pip
+                    pip install --upgrade cffi
 
-                  pip install ansible==2.4.2.0
-                  pip install boto
+                    pip install ansible==2.4.2.0
+                    pip install boto
 
-                  packer build -color=false \
-                    -var 'vault_password_file=${vp}' \
-                    -var 'git_branch=${params.BB20_APP_VERSION}' \
-                    -var 'subnet_id=${params.SUBNET_ID}' \
-                    -var 'source_ami=${params.GDIT_GOLD_IMAGE_AMI_ID}' \
-                    -var 'release_version=${release_version}' \
-                    packer/build_platinum_ami.json 2>&1 | tee platinum_packer_output.txt
-                """
+                    packer build -color=false \
+                      -var 'vault_password_file=${vp}' \
+                      -var 'git_branch=${params.BB20_APP_VERSION}' \
+                      -var 'subnet_id=${params.SUBNET_ID}' \
+                      -var 'source_ami=${params.GDIT_GOLD_IMAGE_AMI_ID}' \
+                      -var 'release_version=${release_version}' \
+                      packer/build_platinum_ami.json 2>&1 | tee platinum_packer_output.txt
+                  """
+                }
+                catch (Exception e) {
+                  helpers.slackNotify("FAILED!", 'bad')
+                }
               }
             }
           }

--- a/Jenkinsfiles/Jenkinsfile.build_platinum_ami
+++ b/Jenkinsfiles/Jenkinsfile.build_platinum_ami
@@ -7,7 +7,7 @@ def helpers
 pipeline {
   agent {
     node {
-      label ''
+      label 'rhel7-scheduled'
       customWorkspace 'blue-button-build-platinum-ami'
     }
   }
@@ -58,11 +58,13 @@ pipeline {
       steps {
         script {
           if (params.GDIT_GOLD_IMAGE_AMI_ID == '') {
-            GDIT_GOLD_IMAGE_AMI_ID = sh(returnStdout: true, script: """/usr/local/bin/aws ec2 describe-images --filters \
-            'Name=name,Values=\"EAST-RH 7-? Gold Image V.1.?? (HVM) ??-??-??\"' \
-            'Name=state,Values=available' --region us-east-1 --output json | \
-            jq -r '.Images | sort_by(.CreationDate) | last(.[]).ImageId'"""
-            ).trim()
+            GDIT_GOLD_IMAGE_AMI_ID = sh(
+              returnStdout: true, 
+              script: "/usr/local/bin/aws ec2 describe-images --filters \
+              'Name=name,Values=\"EAST-RH 7-? Gold Image V.1.?? (HVM) ??-??-??\"' \
+              'Name=state,Values=available' --region us-east-1 --output json | \
+              jq -r '.Images | sort_by(.CreationDate) | last(.[]).ImageId'"
+              ).trim()
             echo "LATEST GOLD IMAGE AMI: ${GDIT_GOLD_IMAGE_AMI_ID}" 
           }
           else {
@@ -149,6 +151,7 @@ pipeline {
                 }
                 catch (Exception e) {
                   helpers.slackNotify("FAILED!", 'bad')
+                  currentBuild.result = 'FAILURE'
                 }
               }
             }
@@ -163,6 +166,10 @@ pipeline {
                 dir('code') {
                     BB20_PLATINUM_AMI_ID = sh(returnStdout: true, script: """grep 'us-east-1: ami-' platinum_packer_output.txt | cut -d ' ' -f2 | tr '\n' ' ' | sed -e 's/ //g'""")
                     echo "BB20 PLATINUM AMI: ${BB20_PLATINUM_AMI_ID}"
+                    if( "${BB20_PLATINUM_AMI_ID}" == '' ) {
+                    currentBuild.result = 'FAILED'
+                    return
+                    }
                 }
             }
         }

--- a/Jenkinsfiles/Jenkinsfile.build_platinum_ami
+++ b/Jenkinsfiles/Jenkinsfile.build_platinum_ami
@@ -28,7 +28,7 @@ pipeline {
       name: 'BB20_DEPLOY_BRANCH'
     )
     string(
-      defaultValue: "ami-0cb990abf4037fa2b",
+      defaultValue: "",
       description: 'The AMI ID of the GDIT Gold Image.',
       name: 'GDIT_GOLD_IMAGE_AMI_ID'
     )

--- a/Jenkinsfiles/Jenkinsfile.build_platinum_ami
+++ b/Jenkinsfiles/Jenkinsfile.build_platinum_ami
@@ -54,6 +54,18 @@ pipeline {
       }
     }
 
+    stage('Acquire Latest Gold AMI'){
+      steps {
+        script {
+          GDIT_GOLD_IMAGE_AMI_ID = sh(returnStdout: true, script: """/usr/local/bin/aws ec2 describe-images --filters \
+          'Name=name,Values=\"EAST-RH 7-? Gold Image V.1.?? (HVM) ??-??-??\"' \
+          'Name=state,Values=available' --region us-east-1 --output json | \
+          jq -r '.Images | sort_by(.CreationDate) | last(.[]).ImageId'""")
+          echo "LATEST GOLD IMAGE AMI: ${GDIT_GOLD_IMAGE_AMI_ID}"
+        }
+      }
+    }
+
     stage('Ensure Params') {
       steps {
         sh """


### PR DESCRIPTION
This PR refactors the Platinum AMI jenkins job and add better error handling for slack notifications. 

Things that were done:
1. Moved Build Platinum AMI to the PROD nodes of Cloudbees. This was necessary to get the job to run on a node that had RH7 and therefore could use jq preoperly. 
2. Removed default value for Gold AMI parameter. 
3. Added step to auto acquire latest gold AMI only IF Gold AMI value is left blank (default). 
4. Added error handling to 'Build Platinum AMI' step and invoking slack notifier. 

Now, this job will run nightly and grabs the latest gold AMI for Redhat 7.X that's available. If for some reason a Gold AMI is introduced that breaks our builds, we can supply a custom AMI value (last know working version) to continue and build platinum AMI's as needed. 

TO DO:
Move the Build App AMI (Agnostic) and Deploy AMI Jobs (For Each Env) to PROD. - BLUEBUTTON-1643

Testing:
I've tested the job to confirm that the Gold AMI parameter is properly set if let blank or if supplied directly. I confirmed that if the Build step fails, slack is notified of the failure. 

Security: 
I see no security implications to these changes, and in fact we are exposing less of our AWS resources with the removal of the Gold AMI ID. 

