### PR TITLE
BB2-117: Ensure app logs are processed in UTC, remove system logs from cloudwatch

### DIFF
--- a/roles/cloudwatch_agent_app/templates/cwagent-app.json.j2
+++ b/roles/cloudwatch_agent_app/templates/cwagent-app.json.j2
@@ -4,18 +4,6 @@
       "files": {
         "collect_list": [
           {
-            "file_path": "/var/log/messages",
-            "log_group_name": "/bb/{{ env }}/var/log/messages",
-            "log_stream_name": "{instance_id}",
-            "timestamp_format": "%b %d %H:%M:%S"
-          },
-          {
-            "file_path": "/var/log/secure",
-            "log_group_name": "/bb/{{ env }}/var/log/secure",
-            "log_stream_name": "{instance_id}",
-            "timestamp_format": "%b %d %H:%M:%S"
-          },
-          {
             "file_path": "{{ app_log_dir }}/debug.log",
             "log_group_name": "/bb/{{ env }}/app/debug.log",
             "log_stream_name": "{instance_id}",

--- a/roles/cloudwatch_agent_app/templates/cwagent-app.json.j2
+++ b/roles/cloudwatch_agent_app/templates/cwagent-app.json.j2
@@ -19,36 +19,42 @@
             "file_path": "{{ app_log_dir }}/debug.log",
             "log_group_name": "/bb/{{ env }}/app/debug.log",
             "log_stream_name": "{instance_id}",
+            "timezone": "UTC",
             "timestamp_format": "%Y-%m-%d %H:%M:%S"
           },
           {
             "file_path": "{{ app_log_dir }}/error.log",
             "log_group_name": "/bb/{{ env }}/app/error.log",
             "log_stream_name": "{instance_id}",
+            "timezone": "UTC",
             "timestamp_format": "%Y-%m-%d %H:%M:%S"
           },
           {
             "file_path": "{{ app_log_dir }}/info.log",
             "log_group_name": "/bb/{{ env }}/app/info.log",
             "log_stream_name": "{instance_id}",
+            "timezone": "UTC",
             "timestamp_format": "%Y-%m-%d %H:%M:%S"
           },
           {
             "file_path": "{{ app_log_dir }}/login_failed.log",
             "log_group_name": "/bb/{{ env }}/app/login_failed.log",
             "log_stream_name": "{instance_id}",
+            "timezone": "UTC",
             "timestamp_format": "%Y-%m-%d %H:%M:%S"
           },
           {
             "file_path": "{{ app_log_dir }}/admin_access.log",
             "log_group_name": "/bb/{{ env }}/app/admin_access.log",
             "log_stream_name": "{instance_id}",
+            "timezone": "UTC",
             "timestamp_format": "%Y-%m-%d %H:%M:%S"
           },
           {
             "file_path": "{{ app_log_dir }}/perf_mon.log",
             "log_group_name": "/bb/{{ env }}/app/perf_mon.log",
             "log_stream_name": "{instance_id}",
+            "timezone": "UTC",
             "timestamp_format": "%Y-%m-%d %H:%M:%S"
           }
         ]


### PR DESCRIPTION

### Change Details

- Fixes intermittent app log ingestion issues caused by mismatched timezones on the local system and app logs
- Remove system log ingestion due to the fact that cloudwatch agent cannot handle log files populated before its own startup

### Acceptance Validation

Validate my thinking here:
- I've tested this branch in both dev and test and I'm not seeing any more intermittent issues ingesting app logs
- The only way I can get cloudwatch to correctly ingest system logs is to zero them out before the agent starts.  This issue also affects BFD so I suggest we backog it and come up with a joint solution.

### External References

- [BB2-117](https://jira.cms.gov/browse/BB2-117)

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] altered security controls

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications
<!-- Use this to indicate you're unsure how this change may impact system security and would like to solicit the team's feedback. Optionally, provide background information regarding your questions and concerns. -->

