### PR TITLE
BB2-233: Add CSP report only header

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,59 +1,101 @@
 <!--
-
---- PR Hygiene Checklist ---
-
-1. Make sure the changeset can be reviewed, keep it's scope and size succinct 
-2. Make sure your branch is from your fork and has a meaningful name
-3. Update the PR title: `BLUEBUTTON-99999 Add Awesomeness`
-4. Edit the text below - do not leave placeholders in the text.
-4.1. Remove sections that you don't feel apply
-5. Add any other details that will be helpful for the reviewers: details description, screenshots, etc
-6. Request a review from someone/multiple someones
-7. <optional> Review your changes yourself and write up any comments / concerns as if you were reviewing someone else's code.
+You've got a Pull Request you want to submit? Awesome!
+This PR template is here to help ensure you're setup for success:
+  please fill it out to help ensure that your PR is complete and ready for approval.
 -->
 
-### Change Details
+**JIRA Ticket:**
+[SOMEPROJECT-42](https://jira.cms.gov/browse/SOMEPROJECT-42)
 
-<!-- Add detailed discussion of changes here: -->
-<!-- This is likely a summary, or the complete contents, of your commit messages -->
+**User Story or Bug Summary:**
+<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->
 
-### Acceptance Validation
 
-<!-- What should reviewers look for to determine completeness -->
+### What Does This PR Do?
 
-<!-- Insert screenshots if applicable (drag images here) -->
+<!--
+Add detailed description & discussion of changes here.
+The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).
 
-### Feedback Requested
+Please follow standard Git commit message guidelines:
+* First line should be a capitalized, short (50 chars or less) summary.
+* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
+* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
+* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.
 
-<!-- What type of feedback you want from your reviewers? -->
+Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
+-->
 
-### External References
 
-<!-- For example: replace xxx with the JIRA ticket number: -->
+### What Should Reviewers Watch For?
 
-- [BLUEBUTTON-xxx](https://jira.cms.gov/browse/BLUEBUTTON-xxx)
+<!--
+Add some items to the following list, or remove the entire section if it doesn't apply for some reason.
 
-### Security Implications
+Common items include:
+* Is this likely to address the goals expressed in the user story?
+* Are any additional documentation updates needed?
+* Are there any unhandled and/or untested edge cases you can think of?
+* Is user input properly sanitized & handled?
+* Does this make any backwards-incompatible changes that might break end user clients?
+* Can you find any bugs if you run the code locally and test it manually?
+-->
 
-<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
-terms of security concerns? -->
+If you're reviewing this PR, please check these things, in particular:
 
-- [ ] new software dependencies
+* TODO
 
-<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->
 
-- [ ] altered security controls
+### What Security Implications Does This PR Have?
 
-<!-- If yes, what security controls or supporting software are affected? -->
+Submitters should complete the following questionnaire:
 
-- [ ] new data stored or transmitted
+* If the answer to any of the questions below is **Yes**, then here's a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence: N/A.
+    * Does this PR add any new software dependencies? **Yes** or **No**.
+    * Does this PR modify or invalidate any of our security controls? **Yes** or **No**.
+    * Does this PR store or transmit data that was not stored or transmitted before? **Yes** or **No**.
+* If the answer to any of the questions below is **Yes**, then please add @StewGoin as a reviewer, and note that this PR should not be merged unless/until he also approves it.
+    * Do you think this PR requires additional review of its security implications for other reasons? **Yes** or **No**.
 
-<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->
 
-- [ ] security checklist is completed for this change
+### What Needs to Be Merged and Deployed Before this PR?
 
-<!-- If yes, provide a link to the security checklist in Confluence here. -->
+<!--
+Add some items to the following list, or remove the entire section if it doesn't apply.
 
-- [ ] requires more information or team discussion to evaluate security implications
-<!-- Use this to indicate you're unsure how this change may impact system security and would like to solicit the team's feedback. Optionally, provide background information regarding your questions and concerns. -->
+Common items include:
+* Database migrations (which should always be deployed by themselves, to reduce risk).
+* New features in external dependencies (e.g. BFD).
+-->
 
+This PR cannot be either merged or deployed until the following pre-requisite changes have been fully deployed:
+
+* CMSgov/some_repo#42
+
+
+### Submitter Checklist
+
+<!--
+Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
+See these resources for more information:
+
+* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
+* <https://raphaelfabeni.com/git-editing-commits-part-1/>
+-->
+
+I have gone through and verified that...:
+
+* [ ] This PR is reasonably limited in scope, to help ensure that:
+    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
+    2. There isn't too much of a burden on reviewers.
+    3. Any problems it causes have a small "blast radius".
+    4. It'll be easier to rollback if that becomes necessary.
+* [ ] I have named this PR and its branch such that they'll be automatically be linked to the (most) relevant Jira issue, per: <https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html>.
+* [ ] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
+* [ ] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
+* [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
+* [ ] Reviews are requested from both:
+    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
+    * Any relevant engineers on other projects (e.g. BFD, SLS, etc.).
+* [ ] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
+    * Please review the standards every few months to ensure you're familiar with them.

--- a/roles/nginx_uwsgi_config/files/nginx.conf
+++ b/roles/nginx_uwsgi_config/files/nginx.conf
@@ -37,7 +37,7 @@ http {
     server_tokens off;
 
     # BB2-233 enabled CSP in report only mode
-    add_header Content-Security-Policy-Report-Only "default-src 'self' https://s3.amazonaws.com/content-dev-bbonfhir-com/ https://s3.amazonaws.com/content-test-bbonfhir-com/ https://s3.amazonaws.com/content-impl-bbonfhir-com/ https://s3.amazonaws.com/content-prod-bbonfhir-com/ https://ajax.googleapis.com https://stackpath.bootstrapcdn.com/bootstrap/ https://unpkg.com/feather-icons https://fonts.googleapis.com https://fonts.gstatic.com";
+    add_header Content-Security-Policy-Report-Only "default-src 'self' https://s3.amazonaws.com/{{ env_s3_storage_bucket_name }}/ https://ajax.googleapis.com https://stackpath.bootstrapcdn.com/bootstrap/ https://unpkg.com/feather-icons https://fonts.googleapis.com https://fonts.gstatic.com";
 
     # enforce HSTS policy (force clients to use HTTPS)
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload";

--- a/roles/nginx_uwsgi_config/files/nginx.conf
+++ b/roles/nginx_uwsgi_config/files/nginx.conf
@@ -41,6 +41,9 @@ http {
     add_header X-Content-Type-Options nosniff;
     add_header X-Frame-Options DENY;
 
+    # BB2-52 enforce referrer policy
+    add_header Referrer-Policy strict-origin-when-cross-origin;
+
     ssl_certificate     /etc/ssl/certs/cert.pem;
     ssl_certificate_key /etc/ssl/certs/key.pem;
 

--- a/roles/nginx_uwsgi_config/files/nginx.conf
+++ b/roles/nginx_uwsgi_config/files/nginx.conf
@@ -36,6 +36,9 @@ http {
     server_name _;
     server_tokens off;
 
+    # BB2-233 enabled CSP in report only mode
+    add_header Content-Security-Policy-Report-Only "default-src 'self' https://s3.amazonaws.com/content-dev-bbonfhir-com/ https://s3.amazonaws.com/content-test-bbonfhir-com/ https://s3.amazonaws.com/content-impl-bbonfhir-com/ https://s3.amazonaws.com/content-prod-bbonfhir-com/ https://ajax.googleapis.com https://stackpath.bootstrapcdn.com/bootstrap/ https://unpkg.com/feather-icons https://fonts.googleapis.com https://fonts.gstatic.com";
+
     # enforce HSTS policy (force clients to use HTTPS)
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload";
     add_header X-Content-Type-Options nosniff;


### PR DESCRIPTION
### Change Details

This sets the `Content-Security-Policy-Report-Only` header to a relatively sane value set of the default sources we require for our externally loaded scripts, stylesheets, fonts, etc.

It is currently in report only mode due to the fact that we have inline bits of script and style hanging out in a lot of places, and we will need to identify and resolve those before we can move to enforcing mode.

A good overview can be found here: https://developers.google.com/web/fundamentals/security/csp

### Acceptance Validation

Enabling CSP in report only mode won't break any functionality.  I've refactored the PR to use an existing ansible env var to pull the S3 content bucket name per environment.

### External References

<!-- For example: replace xxx with the JIRA ticket number: -->

- [BB2-233](https://jira.cms.gov/browse/BB2-233)

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [ ] altered security controls

<!-- If yes, what security controls or supporting software are affected? -->

- [ ] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications
<!-- Use this to indicate you're unsure how this change may impact system security and would like to solicit the team's feedback. Optionally, provide background information regarding your questions and concerns. -->

