### PR TITLE
BB2-636: Disable New Relic high security mode in agent config

### DIFF
--- a/roles/new_relic/templates/newrelic.ini.j2
+++ b/roles/new_relic/templates/newrelic.ini.j2
@@ -74,7 +74,7 @@ log_level = info
 # server-side configuration in the New Relic user interface. For
 # details, see
 # https://docs.newrelic.com/docs/subscriptions/high-security
-high_security = true
+high_security = false
 
 # The Python Agent will attempt to connect directly to the New
 # Relic service. If there is an intermediate firewall between


### PR DESCRIPTION

**JIRA Ticket:**
[BB2-636](https://jira.cms.gov/browse/BB2-636)
[BFD-724](https://jira.cms.gov/browse/BFD-724)

**User Story or Bug Summary:**
Requisite to changes for BFD, high security mode must be disabled in our New Relic account as it is shared between both projects. We should disable this in our agent config as well to be consistent, even if not required (ex. server side settings override agent settings).


### What Does This PR Do?

This simply sets `high_security = false` in the New Relic agent config.


### What Should Reviewers Watch For?

N/A


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then here's a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence: N/A.
    * Does this PR add any new software dependencies? **No**.
    * Does this PR modify or invalidate any of our security controls? **No**.
    * Does this PR store or transmit data that was not stored or transmitted before? **Yes**
* If the answer to any of the questions below is **Yes**, then please add @StewGoin as a reviewer, and note that this PR should not be merged unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons? **No**.

Note that an SIA has been completed for BFD and is not needed for BB2: https://confluence.cms.gov/pages/viewpage.action?spaceKey=BFD&title=2020-04-28+New+Relic-+Disable+High+Security+Mode


### What Needs to Be Merged and Deployed Before this PR?

New Relic server side changes (to be completed by New Relic support)


### Submitter Checklist

I have gone through and verified that...:

* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] I have named this PR and its branch such that they'll be automatically be linked to the (most) relevant Jira issue, per: <https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html>.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. BFD, SLS, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
