### PR TITLE
UWSGI - update buffer size 4k -> 32k

### DIFF
--- a/roles/nginx_uwsgi_config/files/nginx.conf
+++ b/roles/nginx_uwsgi_config/files/nginx.conf
@@ -69,6 +69,7 @@ http {
     location / {
       include                 uwsgi_params;
       uwsgi_pass              application;
+      uwsgi_buffer_size       32k;
       proxy_buffers           4 32k;
       client_max_body_size    8m;
       client_body_buffer_size 128k;


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
N/A

### What Does This PR Do?
Increases the UWSGI buffer size from a default 4k -> 32k to prevent nginx 502s. 

### What Should Reviewers Watch For?
No other changes beyond a single line. 

### Validation

We will validate this in the test environment using a header that previously induced 502s. 

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security?

- [ ] Yes, one or more of the above security implications apply. This PR must not be merged without the ISSO or team security engineer's approval.
