### PR TITLE
Update test image to use Python 3.12

### DIFF
--- a/Dockerfiles/Dockerfile.cbc-build
+++ b/Dockerfiles/Dockerfile.cbc-build
@@ -1,8 +1,9 @@
 # ==============================
 # Base Image
 # ==============================
-ARG PYTHON_VERSION
-FROM --platform=linux/amd64 python:${PYTHON_VERSION}
+# ARG requires a default value when used in a FROM
+ARG PYTHON_VERSION=3.12.8
+FROM python:${PYTHON_VERSION}
 
 # ==============================
 # Build Arguments

--- a/Dockerfiles/cbc-build-push.sh
+++ b/Dockerfiles/cbc-build-push.sh
@@ -3,10 +3,10 @@
 # TO-DO: pin versions on boto3 and botocore if requested.
 # Versions at time of BB2-1124 dev: boto3==1.21.28 botocore==1.24.28
 
-DOCKER_TAG=${1:-py311-ans11-awscol620-ot10-tgrunt85-boto3-botocore-V4}
+DOCKER_TAG=${1:-py312-ans11-awscol620-ot10-tgrunt85-boto3-botocore-V4}
 
 docker build --file Dockerfile.cbc-build \
-  --build-arg PYTHON_VERSION=${2:-3.11.9} \
+  --build-arg PYTHON_VERSION=${2:-3.12.8} \
   --build-arg ANSIBLE_VERSION=${3:-11.0.0} \
   --build-arg PACKER_VERSION=${4:-1.11.2} \
   --build-arg TERRAFORM_VERSION=${5:-1.13.3} \

--- a/Dockerfiles/cbc-build-push.sh
+++ b/Dockerfiles/cbc-build-push.sh
@@ -5,7 +5,9 @@
 
 DOCKER_TAG=${1:-py312-ans11-awscol620-ot10-tgrunt85-boto3-botocore-V4}
 
-docker build --file Dockerfile.cbc-build \
+docker build \
+  --platform "linux/amd64" \
+  --file Dockerfile.cbc-build \
   --build-arg PYTHON_VERSION=${2:-3.12.8} \
   --build-arg ANSIBLE_VERSION=${3:-11.0.0} \
   --build-arg PACKER_VERSION=${4:-1.11.2} \

--- a/Jenkinsfiles/cbc-build_V1.yaml
+++ b/Jenkinsfiles/cbc-build_V1.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
     - name: bb2-cbc-build
-      image: "public.ecr.aws/q8j7a4l4/bb2-cbc-build:py311-ans11-awscol620-ot10-tgrunt85-boto3-botocore-V4"
+      image: "public.ecr.aws/q8j7a4l4/bb2-cbc-build:py312-ans11-awscol620-ot10-tgrunt85-boto3-botocore-V4"
       tty: true
       command: ["tail", "-f", "/dev/null"]
       imagePullPolicy: Always

--- a/Jenkinsfiles/cbc-build_django.yaml
+++ b/Jenkinsfiles/cbc-build_django.yaml
@@ -3,7 +3,7 @@ kind: Pod
 spec:
   containers:
     - name: bb2-cbc-build
-      image: "public.ecr.aws/q8j7a4l4/bb2-cbc-build:py311-ans29-awscol620-tf18-tgrunt-boto3-botocore"
+      image: "public.ecr.aws/q8j7a4l4/bb2-cbc-build:py312-ans29-awscol620-tf18-tgrunt-boto3-botocore"
       tty: true
       command: ["tail", "-f", "/dev/null"]
       imagePullPolicy: Always

--- a/playbook/run_django_command/main.yml
+++ b/playbook/run_django_command/main.yml
@@ -21,7 +21,7 @@
         app_path: "{{ install_root }}/{{ project_name }}/"
         virtualenv: "{{ venv_full }}"
       register: django_command_debug
-      async: 1800
+      async: 3600
       poll: 10
     - name: "Display command output: {{ django_command }}"
       run_once: yes


### PR DESCRIPTION
The test/build image was not on Python 3.12, which blocks updating to Django 6.0.2.

**JIRA Ticket:**
[BB2-4504](https://jira.cms.gov/browse/BB2-4504)


### What Does This PR Do?

Updates the test runner image to use Python 3.12.

### What Should Reviewers Watch For?

Does the pipeline succeed?

### What Security Implications Does This PR Have?

No security implications.
